### PR TITLE
fix: access object configs in NP EngineNodes. Allow sens=0, act=0

### DIFF
--- a/eagerx/core/entities.py
+++ b/eagerx/core/entities.py
@@ -679,18 +679,20 @@ class EngineNode(Node):
     Use baseclass :class:`~eagerx.core.entities.ResetNode` instead, for reset routines.
     """
 
-    def __init__(self, object_name: str, simulator: Any = None, **kwargs: Any):
-        config = get_param_with_blocking(object_name)
-        if config is None:
-            rospy.logwarn(
-                f"Parameters for object registry request ({object_name}) not found on parameter server. "
-                f"Timeout: object ({object_name}) not registered."
-            )
-        try:
-            bridge_config = config.pop("bridge")
-        except KeyError:
-            bridge_config = {}
-
+    def __init__(self, object_name: str = None, simulator: Any = None, **kwargs: Any):
+        if object_name:
+            config = get_param_with_blocking(object_name)
+            if config is None:
+                rospy.logwarn(
+                    f"Parameters for object registry request ({object_name}) not found on parameter server. "
+                    f"Timeout: object ({object_name}) not registered."
+                )
+            try:
+                bridge_config = config.pop("bridge")
+            except KeyError:
+                bridge_config = {}
+        else:
+            config, bridge_config = None, None
         #: A reference to the :attr:`~eagerx.core.entities.Bridge.simulator`. The simulator type depends on the bridge.
         #: Oftentimes, engine nodes require this reference in :func:`~eagerx.core.entities.EngineNode.callback` and/or
         #: :func:`~eagerx.core.entities.EngineNode.reset` to simulate (e.g. apply an action, extract a sensor measurement).

--- a/eagerx/core/executable_bridge.py
+++ b/eagerx/core/executable_bridge.py
@@ -140,7 +140,7 @@ class RxBridge(object):
 
 if __name__ == "__main__":
     try:
-        executable, ns, name = sys.argv[0], sys.argv[-2], sys.argv[-1]
+        executable, ns, name, _ = sys.argv[0], sys.argv[-3], sys.argv[-2], sys.argv[-1]
 
         log_level = get_param_with_blocking(ns + "/log_level")
 

--- a/eagerx/core/executable_node.py
+++ b/eagerx/core/executable_node.py
@@ -150,7 +150,7 @@ class RxNode(object):
 
 if __name__ == "__main__":
     try:
-        executable, ns, name = sys.argv[0], sys.argv[-2], sys.argv[-1]
+        executable, ns, name, object_name = sys.argv[0], sys.argv[-3], sys.argv[-2], sys.argv[-1]
 
         log_level = get_param_with_blocking(ns + "/log_level")
 
@@ -162,7 +162,7 @@ if __name__ == "__main__":
 
         message_broker = eagerx.core.rx_message_broker.RxMessageBroker(owner=f"{ns}/{name}")
 
-        pnode = RxNode(name=f"{ns}/{name}", message_broker=message_broker)
+        pnode = RxNode(name=f"{ns}/{name}", message_broker=message_broker, object_name=f"{ns}/{object_name}")
 
         message_broker.connect_io()
 

--- a/eagerx/core/graph_engine.py
+++ b/eagerx/core/graph_engine.py
@@ -690,8 +690,8 @@ class EngineGraph:
                     substitute_args(params, context, only=["config", "ns"])
                     nodes[name] = params
 
-        assert len(actuators) > 0, "No actuators node defined in the graph."
-        assert len(sensors) > 0, "No sensors node defined in the graph."
+        # assert len(actuators) > 0, "No actuators node defined in the graph."
+        # assert len(sensors) > 0, "No sensors node defined in the graph."
         return nodes, actuators, sensors
 
     def gui(self) -> None:

--- a/eagerx/core/supervisor.py
+++ b/eagerx/core/supervisor.py
@@ -118,6 +118,11 @@ class SupervisorNode(BaseNode):
         params, nodes = object.build(ns=self.ns, bridge_id=bridge_name)
         rosparam.upload_params(self.ns, params)
 
+        # Set node args
+        node_args = dict(
+            object_name=f"{self.ns}/{obj_name}",
+        )
+
         # Upload node parameters to ROS param server
         initialize_nodes(
             nodes,
@@ -127,8 +132,10 @@ class SupervisorNode(BaseNode):
             is_initialized=self.is_initialized,
             sp_nodes=self.sp_nodes,
             launch_nodes=self.launch_nodes,
+            node_args=node_args,
+            object_name=obj_name,
         )
-        self.subjects["register_object"].on_next(String(self.ns + "/" + obj_name))
+        self.subjects["register_object"].on_next(String(f"{self.ns}/{obj_name}"))
 
     def _get_states(self, reset_msg):
         # Fill output_msg with buffered states

--- a/eagerx/utils/node_utils.py
+++ b/eagerx/utils/node_utils.py
@@ -57,12 +57,12 @@ def launch_node(launch_file, args):
     return launch
 
 
-def launch_node_as_subprocess(executable, ns, name):
+def launch_node_as_subprocess(executable: str, ns: str, name: str, object_name: str):
     node_type, file = executable.split(":=")
     if "python" in node_type:
         if ".py" not in file:
             file = importlib.import_module(file).__file__
-    p = subprocess.Popen([file] + [ns, name])
+    p = subprocess.Popen([file] + [ns, name, object_name])
     return p
 
 
@@ -76,7 +76,7 @@ def initialize_nodes(
     launch_nodes: Dict,
     rxnode_cls: Any = None,
     node_args: Dict = None,
-    subscribers: List = None,
+    object_name: str = "",
 ):
     if rxnode_cls is None:
         from eagerx.core.executable_node import RxNode
@@ -136,7 +136,7 @@ def initialize_nodes(
                 'No executable defined. Node "%s" can only be launched as a separate process if an executable is specified.'
                 % name
             )
-            launch_nodes[node_address] = launch_node_as_subprocess(params["executable"], ns, name)
+            launch_nodes[node_address] = launch_node_as_subprocess(params["executable"], ns, name, object_name)
         elif params["process"] == process.EXTERNAL:
             rospy.loginfo('Node "%s" must be manually launched as the process is specified as process.EXTERNAL' % name)
         # else: node is launched in another (already launched) node's process (e.g. bridge process).


### PR DESCRIPTION
- `EngineNodes` grab the object's `config` & `bridge_config` from the rosparam server. In this way, `EngineNodes` also have access to the parameters when launched as a `NEW_PROCESS`

- Remove assertions that force an object to have `len(sensors)>0`, `len(actuators)>0` as it works. Closes #113.