### PR TITLE
fix: colab modifications

### DIFF
--- a/docs/_shared/bridge_node.rst
+++ b/docs/_shared/bridge_node.rst
@@ -37,7 +37,7 @@ First of all, there are the standard parameters for the :class:`~eagerx.core.ent
 
 * :attr:`~eagerx.core.entities.Bridge.rate`
 * :attr:`~eagerx.core.entities.Bridge.process`
-* :attr:`~eagerx.core.entities.Bridge.is_reactive`
+* :attr:`~eagerx.core.entities.Bridge.sync`
 * :attr:`~eagerx.core.entities.Bridge.real_time_factor`
 * :attr:`~eagerx.core.entities.Bridge.simulate_delays`
 * :attr:`~eagerx.core.entities.Bridge.log_level`
@@ -79,7 +79,7 @@ We can define the default values for all of these parameters using the spec func
           spec: BridgeSpec,
           rate,
           process: Optional[int] = process.NEW_PROCESS,
-          is_reactive: Optional[bool] = True,
+          sync: Optional[bool] = True,
           real_time_factor: Optional[float] = 0,
           simulate_delays: Optional[bool] = True,
           log_level: Optional[int] = ERROR,
@@ -95,7 +95,7 @@ We can define the default values for all of these parameters using the spec func
           # Modify default bridge params
           spec.config.rate = rate
           spec.config.process = process
-          spec.config.is_reactive = is_reactive
+          spec.config.sync = sync
           spec.config.real_time_factor = real_time_factor
           spec.config.simulate_delays = simulate_delays
           spec.config.log_level = log_level

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -43,7 +43,7 @@ class Mock(MagicMock):
 # 'torch', 'torch.nn', 'torch.nn.functional',
 # DO not mock modules for now, we will need to do that for read the docs later
 # autodoc_mock_imports = ["rosgraph", "roslaunch"]
-MOCK_MODULES = ["rospy", "rosparam", "rosgraph", "roslaunch", "genpy", "std_msgs.msg", "sensor_msgs.msg", "cv_bridge"]
+MOCK_MODULES = ["rospy", "rosparam", "rosgraph", "roslaunch", "rosservice", "genpy", "std_msgs.msg", "sensor_msgs.msg", "cv_bridge"]
 sys.modules.update((mod_name, Mock()) for mod_name in MOCK_MODULES)
 
 

--- a/docs/guide/tutorials/pendulum/learn.rst
+++ b/docs/guide/tutorials/pendulum/learn.rst
@@ -15,8 +15,8 @@ After creating the :mod:`~eagerx.core.graph.Graph`, we will also :func:`~eagerx.
 ::
 
   # Define bridges
-  bridge_ode = Bridge.make('OdeBridge', rate=rate, is_reactive=True, real_time_factor=0, process=process.NEW_PROCESS)
-  bridge_real = Bridge.make('RealBridge', rate=rate, is_reactive=True, process=process.NEW_PROCESS)
+  bridge_ode = Bridge.make('OdeBridge', rate=rate, sync=True, real_time_factor=0, process=process.NEW_PROCESS)
+  bridge_real = Bridge.make('RealBridge', rate=rate, sync=True, process=process.NEW_PROCESS)
 
 EagerxEnv
 #########

--- a/eagerx/bridges/openai_gym/bridge.py
+++ b/eagerx/bridges/openai_gym/bridge.py
@@ -23,7 +23,7 @@ class GymBridge(Bridge):
         spec: BridgeSpec,
         rate,
         process: Optional[int] = process.NEW_PROCESS,
-        is_reactive: Optional[bool] = True,
+        sync: Optional[bool] = True,
         real_time_factor: Optional[float] = 0,
         simulate_delays: Optional[bool] = True,
         log_level: Optional[int] = ERROR,
@@ -35,7 +35,7 @@ class GymBridge(Bridge):
         # Modify default bridge params
         spec.config.rate = rate
         spec.config.process = process
-        spec.config.is_reactive = is_reactive
+        spec.config.sync = sync
         spec.config.real_time_factor = real_time_factor
         spec.config.simulate_delays = simulate_delays
         spec.config.log_level = log_level

--- a/eagerx/bridges/openai_gym/bridge.py
+++ b/eagerx/bridges/openai_gym/bridge.py
@@ -1,11 +1,10 @@
 # OTHER
-from typing import Optional, Dict, Union, List
+from typing import Optional
 import gym
 
 # ROS IMPORTS
 import rospy
 from std_msgs.msg import UInt64
-from genpy.message import Message
 
 # RX IMPORTS
 from eagerx.core.constants import process, ERROR
@@ -72,7 +71,7 @@ class GymBridge(Bridge):
             sim["buffer_done"] = []
 
     @register.outputs(tick=UInt64)
-    def callback(self, t_n: float, **kwargs: Dict[str, Union[List[Message], float, int]]):
+    def callback(self, t_n: float):
         for _obj_name, sim in self.simulator.items():
             next_action = sim["next_action"]
             obs, reward, is_done, _ = sim["env"].step(next_action)

--- a/eagerx/converters/space_ros_converters.py
+++ b/eagerx/converters/space_ros_converters.py
@@ -18,13 +18,13 @@ class Space_Float32MultiArray(SpaceConverter):
 
     @staticmethod
     @register.spec("Space_Float32MultiArray", SpaceConverter)
-    def spec(spec: ConverterSpec, low=None, high=None, dtype="float32"):
+    def spec(spec: ConverterSpec, low, high, dtype="float32"):
         # Initialize spec with default arguments
         spec.initialize(Space_Float32MultiArray)
         params = dict(low=low, high=high, dtype=dtype)
         spec.config.update(params)
 
-    def initialize(self, low=None, high=None, dtype="float32"):
+    def initialize(self, low, high, dtype="float32"):
         self.low = np.array(low, dtype=dtype)
         self.high = np.array(high, dtype=dtype)
         self.dtype = dtype
@@ -107,14 +107,14 @@ class Space_Float32(SpaceConverter):
 
     @staticmethod
     @register.spec("Space_Float32", SpaceConverter)
-    def spec(spec: ConverterSpec, low=None, high=None, dtype="float32"):
+    def spec(spec: ConverterSpec, low, high, dtype="float32"):
         # Initialize spec with default arguments
         spec.initialize(Space_Float32)
 
         params = dict(low=low, high=high, dtype=dtype)
         spec.config.update(params)
 
-    def initialize(self, low=None, high=None, dtype="float32"):
+    def initialize(self, low, high, dtype="float32"):
         self.low = low
         self.high = high
         assert isinstance(low, (int, float)), "Low must be of type (int, float)."

--- a/eagerx/core/constants.py
+++ b/eagerx/core/constants.py
@@ -102,7 +102,7 @@ GUI_WIDGETS = {
             "targets": ["space_converter"],
             "sensors": ["start_with_msg"],
             "actions": ["start_with_msg", "space_converter", "external_rate"],
-            "observations": ["is_reactive", "rate", "space_converter"],
+            "observations": ["sync", "rate", "space_converter"],
             "outputs": ["rate"],
         },
     },

--- a/eagerx/core/entities.py
+++ b/eagerx/core/entities.py
@@ -1586,6 +1586,34 @@ class SpaceConverter(Converter):
     #: Supported message type
     MSG_TYPE_B: Any
 
+    def __init__(self, *args, initial_obs=None, **kwargs):
+        self._initial_obs = initial_obs
+        super().__init__(*args, **kwargs)
+        if self._initial_obs is not None:
+            self._initial_obs = np.array(self._initial_obs, dtype=self.get_space().dtype)
+            assert self._initial_obs.shape == self.get_space().shape, (
+                "The shape of the initial observation does not match the "
+                f"space of a SpaceConverter of type {self.__qualname__}"
+            )
+
+    @property
+    def initial_obs(self) -> np.ndarray:
+        """An observation that is used on t=0 if this space converter corresponds to an observation that is skipped at t=0
+        with `window` > 0.
+
+        The provided initial observation must comply with the space returned by
+        :func:`~eagerx.core.entities.SpaceConverter.get_space`. This ensures that at t=0, the observation to the agent
+        complies with the environment's observation space when the corresponding connected output (providing the observation)
+        is skipped at t=0.
+
+        .. note:: An initial observation (default=`None`) is added to :func:`~eagerx.core.entities.SpaceConverter.spec` for
+                  users to set. In addition, users can also set/overwrite the observation when connecting the observation with
+                  :func:`~eagerx.core.graph.Graph.connect`.
+
+        :return: The initial observation.
+        """
+        return self._initial_obs
+
     @abc.abstractmethod
     def get_space(self) -> gym.Space:
         """An abstract method that returns the OpenAI's gym space related to converted message."""

--- a/eagerx/core/entities.py
+++ b/eagerx/core/entities.py
@@ -1030,7 +1030,7 @@ class Bridge(BaseNode):
         # Only apply the callback after all pipelines have been initialized
         # Only then, the initial state has been set.
         if self.num_resets >= 1:
-            self.callback(t_n, **kwargs)
+            self.callback(t_n)
         # Fill output msg with number of node ticks
         self.num_ticks += 1
         return dict(tick=UInt64(data=node_tick + 1))
@@ -1132,12 +1132,13 @@ class Bridge(BaseNode):
         pass
 
     @abc.abstractmethod
-    def callback(self, t_n: float, **engine_node_outputs: Msg) -> None:
+    def callback(self, t_n: float) -> None:
         """
         The bridge callback that is performed at the specified rate.
 
         This method should be decorated with :func:`eagerx.core.register.outputs` to register
-        `tick` = :class:`std_msgs.msg.UInt64` as the only output.
+        `tick` = :class:`std_msgs.msg.UInt64` as the only output. This `tick` output synchronizes every
+        :class:`~eagerx.core.entities.EngineNode` that specifies this tick as an input.
 
         This callback is often used to step the simulator by 1/:attr:`~eagerx.core.entities.Bridge.rate`.
 
@@ -1147,13 +1148,7 @@ class Bridge(BaseNode):
                   If you wish to broadcast other output messages based on properties of the simulator,
                   a separate :class:`~eagerx.core.entities.EngineNode` should be created.
 
-        .. note:: The outputs of every :class:`~eagerx.core.entities.EngineNode` for every registered
-                  :class:`~eagerx.core.entities.Object` are automatically registered as input to the bridge to ensure
-                  input-output synchronization.
-
         :param t_n: Time passed (seconds) since last reset. Increments with 1/:attr:`~eagerx.core.entities.Bridge.rate`.
-        :param engine_node_outputs: The outputs of every :class:`~eagerx.core.entities.EngineNode` for every registered
-                                    :class:`~eagerx.core.entities.Object`.
         """
         pass
 

--- a/eagerx/core/env.py
+++ b/eagerx/core/env.py
@@ -173,7 +173,7 @@ class Env(gym.Env):
         mb = RxMessageBroker(owner="%s/%s" % (self.ns, "env"))
 
         # Get info from bridge on reactive properties
-        is_reactive = bridge.config.is_reactive
+        sync = bridge.config.sync
         real_time_factor = bridge.config.real_time_factor
         simulate_delays = bridge.config.simulate_delays
 
@@ -185,7 +185,7 @@ class Env(gym.Env):
         rx_supervisor = Supervisor(
             "%s/%s" % (self.ns, name),
             mb,
-            is_reactive,
+            sync,
             real_time_factor,
             simulate_delays,
         )
@@ -334,7 +334,7 @@ class Env(gym.Env):
     def _set_action(self, action) -> None:
         # Set actions in buffer
         for name, buffer in self.env_node.action_buffer.items():
-            assert not self.supervisor_node.is_reactive or name in action, (
+            assert not self.supervisor_node.sync or name in action, (
                 'Action "%s" not specified. Must specify all actions in action_space if running reactive.' % name
             )
             if name in action:

--- a/eagerx/core/executable_bridge.py
+++ b/eagerx/core/executable_bridge.py
@@ -1,8 +1,10 @@
 #!/usr/bin/env python3
 
 import os
+
 if bool(eval(os.environ.get("EAGERX_COLAB", "0"))):
     import site
+
     site.addsitedir("/opt/ros/melodic/lib/python2.7/dist-packages")
     site.addsitedir("/usr/lib/python2.7/dist-packages")
 

--- a/eagerx/core/executable_bridge.py
+++ b/eagerx/core/executable_bridge.py
@@ -1,5 +1,11 @@
 #!/usr/bin/env python3
 
+import os
+if bool(eval(os.environ.get("EAGERX_COLAB", "0"))):
+    import site
+    site.addsitedir("/opt/ros/melodic/lib/python2.7/dist-packages")
+    site.addsitedir("/usr/lib/python2.7/dist-packages")
+
 import rospy
 from std_msgs.msg import UInt64
 

--- a/eagerx/core/executable_node.py
+++ b/eagerx/core/executable_node.py
@@ -2,8 +2,10 @@
 
 # source ROS if in colab
 import os
+
 if bool(eval(os.environ.get("EAGERX_COLAB", "0"))):
     import site
+
     site.addsitedir("/opt/ros/melodic/lib/python2.7/dist-packages")
     site.addsitedir("/usr/lib/python2.7/dist-packages")
 

--- a/eagerx/core/executable_node.py
+++ b/eagerx/core/executable_node.py
@@ -77,7 +77,7 @@ class RxNode(object):
         rate = params["rate"]
 
         # Get info from bridge on reactive properties
-        is_reactive = get_param_with_blocking(self.ns + "/bridge/is_reactive")
+        sync = get_param_with_blocking(self.ns + "/bridge/sync")
         real_time_factor = get_param_with_blocking(self.ns + "/bridge/real_time_factor")
         simulate_delays = get_param_with_blocking(self.ns + "/bridge/simulate_delays")
 
@@ -86,7 +86,7 @@ class RxNode(object):
         node = node_cls(
             ns=self.ns,
             message_broker=self.mb,
-            is_reactive=is_reactive,
+            sync=sync,
             real_time_factor=real_time_factor,
             simulate_delays=simulate_delays,
             **kwargs,

--- a/eagerx/core/executable_node.py
+++ b/eagerx/core/executable_node.py
@@ -1,5 +1,12 @@
 #!/usr/bin/env python3
 
+# source ROS if in colab
+import os
+if bool(eval(os.environ.get("EAGERX_COLAB", "0"))):
+    import site
+    site.addsitedir("/opt/ros/melodic/lib/python2.7/dist-packages")
+    site.addsitedir("/usr/lib/python2.7/dist-packages")
+
 # ROS imports
 import rospy
 from std_msgs.msg import UInt64

--- a/eagerx/core/graph.py
+++ b/eagerx/core/graph.py
@@ -22,6 +22,7 @@ from eagerx.utils.network_utils import (
     color_edges,
     is_stale,
 )
+import eagerx
 from eagerx.core.entities import Node, BaseConverter, SpaceConverter
 from eagerx.core.view import GraphView
 from eagerx.core.specs import (
@@ -947,6 +948,7 @@ class Graph:
         delay: Optional[float] = None,
         skip: Optional[bool] = None,
         entity_id: str = "Render",
+        process: int = eagerx.process.ENVIRONMENT,
         **kwargs,
     ):
         """Render the :class:`sensor_msgs.msg.Image` messages produced by a node/sensor in the graph.
@@ -975,7 +977,9 @@ class Graph:
         :param skip: Skip the dependency on this input during the first call to the node's :func:`~eagerx.core.entities.Node.callback`.
                      May be necessary to ensure that the connected graph is directed and acyclic.
         :param entity_id: The :attr:`~eagerx.core.entities.Node.entity_id` with which the render node was registered
-                   with the :func:`eagerx.core.register.spec` decorator. By default, it uses the standard Render node.
+                          with the :func:`eagerx.core.register.spec` decorator. By default, it uses the standard Render node.
+        :param process: Process in which the render node is launched. See :class:`~eagerx.core.constants.process` for all
+                        options.
         :param kwargs: Optional arguments required by the render node.
         """
         # Delete old render node from self._state['nodes'] if it exists
@@ -983,7 +987,7 @@ class Graph:
             self.remove("env/render")
 
         # Add (new) render node to self._state['node']
-        render = Node.make(entity_id, rate=rate, **kwargs)
+        render = Node.make(entity_id, rate=rate, process=process, **kwargs)
         self.add(render)
 
         # Create connection

--- a/eagerx/core/graph_engine.py
+++ b/eagerx/core/graph_engine.py
@@ -217,7 +217,7 @@ class EngineGraph:
                               .. warning:: Only add external inputs if you are sure that they are synchronized with respect
                                            to the provided rate and their respective inputs.
                                            Asynchronous external inputs can easily lead to deadlocks if running in synchronized mode
-                                           (i.e. :attr:`~eagerx.core.entities.Bridge.is_reactive` = True).
+                                           (i.e. :attr:`~eagerx.core.entities.Bridge.sync` = True).
         """
         flag = not address or (source is None and actuator is None and sensor is None)
         assert flag, f'You cannot provide an external address "{address}" together with a sensor, actuator, or source.'

--- a/eagerx/core/graph_engine.py
+++ b/eagerx/core/graph_engine.py
@@ -42,6 +42,7 @@ class EngineGraph:
         # Create actuator node
         spec = EngineNode.pre_make(None, None)
         spec.config.name = "actuators"
+        spec.config.color = "yellow"
         nodes.append(spec)
         for cname, params in actuators.items():
             # Determine converted msg_type, based on user-defined input converter
@@ -65,6 +66,7 @@ class EngineGraph:
         # Create sensor node
         spec = EngineNode.pre_make(None, None)
         spec.config.name = "sensors"
+        spec.config.color = "yellow"
         nodes.append(spec)
         for cname, params in sensors.items():
             conv_msg_type = get_opposite_msg_cls_v2(params.msg_type, params.converter)

--- a/eagerx/core/graph_engine.py
+++ b/eagerx/core/graph_engine.py
@@ -52,14 +52,12 @@ class EngineGraph:
                 cname,
                 msg_type=conv_msg_type,
                 converter=ConverterSpec(params.converter.to_dict()),  # Set input converter as output converter
-                space_converter=ConverterSpec(params.space_converter.to_dict()),
             )
             spec.add_input(
                 cname,
                 msg_type=params.msg_type,
                 skip=params.skip,
                 converter=ConverterSpec(params.converter.to_dict()),
-                space_converter=ConverterSpec(params.space_converter.to_dict()),
             )
             spec.config.outputs.append(cname)
 
@@ -75,7 +73,6 @@ class EngineGraph:
                 cname,
                 msg_type=conv_msg_type,
                 converter=ConverterSpec(params.converter.to_dict()),
-                space_converter=ConverterSpec(params.space_converter.to_dict()),
             )
 
         # Create a state

--- a/eagerx/core/nodes.py
+++ b/eagerx/core/nodes.py
@@ -235,9 +235,9 @@ class RenderNode(Node):
         self.last_image = Image(data=[])
         self.render_toggle = False
         self.window_closed = True
-        rospy.Subscriber("%s/%s/toggle" % (self.ns, self.name), Bool, self._set_render_toggle)
-        rospy.Subscriber("%s/%s/get_last_image" % (self.ns, self.name), Bool, self._get_last_image)
-        self.pub_set_last_image = rospy.Publisher(
+        self.sub_toggle = rospy.Subscriber("%s/%s/toggle" % (self.ns, self.name), Bool, self._set_render_toggle)
+        self.sub_get = rospy.Subscriber("%s/%s/get_last_image" % (self.ns, self.name), Bool, self._get_last_image)
+        self.pub_set = rospy.Publisher(
             "%s/%s/set_last_image" % (self.ns, self.name),
             Image,
             queue_size=0,
@@ -246,14 +246,13 @@ class RenderNode(Node):
 
     def _set_render_toggle(self, msg):
         if msg.data:
-
             rospy.loginfo("START RENDERING!")
         else:
             rospy.loginfo("STOP RENDERING!")
         self.render_toggle = msg.data
 
     def _get_last_image(self, msg):
-        self.pub_set_last_image.publish(self.last_image)
+        self.pub_set.publish(self.last_image)
 
     def reset(self):
         pass
@@ -298,4 +297,7 @@ class RenderNode(Node):
 
     def shutdown(self):
         rospy.logdebug(f"[{self.name}] {self.name}.shutdown() called.")
+        self.sub_toggle.unregister()
+        self.sub_get.unregister()
+        self.pub_set.unregister()
         cv2.destroyAllWindows()

--- a/eagerx/core/nodes.py
+++ b/eagerx/core/nodes.py
@@ -219,7 +219,7 @@ class RenderNode(eagerx.Node):
         # Modify default node params
         spec.config.name = "env/render"
         spec.config.rate = rate
-        spec.config.process = eagerx.process.ENVIRONMENT
+        spec.config.process = process
         spec.config.color = color
         spec.config.log_level = log_level
         spec.config.inputs = ["image"]

--- a/eagerx/core/nodes.py
+++ b/eagerx/core/nodes.py
@@ -11,14 +11,15 @@ import cv_bridge
 import cv2
 
 import eagerx
-from eagerx import register
+import eagerx.core.register as register
+from eagerx.core.specs import NodeSpec
 from eagerx.utils.utils import initialize_converter, Msg
 
 
 class EnvNode(eagerx.Node):
     @staticmethod
     @register.spec("Environment", eagerx.Node)
-    def spec(spec: eagerx.specs.NodeSpec, rate=1, log_level=eagerx.log.WARN, color="yellow"):
+    def spec(spec: NodeSpec, rate=1, log_level=eagerx.log.WARN, color="yellow"):
         """EnvNode Spec"""
         spec.initialize(EnvNode)
 
@@ -138,7 +139,7 @@ class EnvNode(eagerx.Node):
 class ObservationsNode(eagerx.Node):
     @staticmethod
     @register.spec("Observations", eagerx.Node)
-    def spec(spec: eagerx.specs.NodeSpec, rate=1, log_level=eagerx.log.WARN, color="yellow"):
+    def spec(spec: NodeSpec, rate=1, log_level=eagerx.log.WARN, color="yellow"):
         """ObservationsNode spec"""
         # Initialize spec
         spec.initialize(ObservationsNode)
@@ -171,7 +172,7 @@ class ObservationsNode(eagerx.Node):
 class ActionsNode(eagerx.Node):
     @staticmethod
     @register.spec("Actions", eagerx.Node)
-    def spec(spec: eagerx.specs.NodeSpec, rate=1, log_level=eagerx.log.WARN, color="yellow"):
+    def spec(spec: NodeSpec, rate=1, log_level=eagerx.log.WARN, color="yellow"):
         """ActionsNode spec"""
         # Initialize spec
         spec.initialize(ActionsNode)
@@ -205,7 +206,7 @@ class RenderNode(eagerx.Node):
     @staticmethod
     @register.spec("Render", eagerx.Node)
     def spec(
-        spec: eagerx.specs.NodeSpec,
+        spec: NodeSpec,
         rate,
         display=True,
         log_level=eagerx.log.WARN,

--- a/eagerx/core/nodes.py
+++ b/eagerx/core/nodes.py
@@ -103,6 +103,11 @@ class EnvNode(Node):
 
             extra = window - len(i.msgs)
             if extra > 0:
+                # Only happens when skip=True && window > 0
+                if len(i.msgs) == 0:
+                    initial_obs = buffer["converter"].initial_obs
+                    i.msgs.append(initial_obs)
+                    extra -= 1  # Subtract, because we appended the initial_obs
                 msgs = extra * [i.msgs[0]] + i.msgs
             else:
                 msgs = i.msgs

--- a/eagerx/core/nodes.py
+++ b/eagerx/core/nodes.py
@@ -10,25 +10,22 @@ from sensor_msgs.msg import Image
 import cv_bridge
 import cv2
 
-
-import eagerx.core.register as register
-from eagerx.core.constants import process, WARN
-from eagerx.core.entities import Node
-from eagerx.core.specs import NodeSpec
+import eagerx
+from eagerx import register
 from eagerx.utils.utils import initialize_converter, Msg
 
 
-class EnvNode(Node):
+class EnvNode(eagerx.Node):
     @staticmethod
-    @register.spec("Environment", Node)
-    def spec(spec: NodeSpec, rate=1, log_level=WARN, color="yellow"):
+    @register.spec("Environment", eagerx.Node)
+    def spec(spec: eagerx.specs.NodeSpec, rate=1, log_level=eagerx.log.WARN, color="yellow"):
         """EnvNode Spec"""
         spec.initialize(EnvNode)
 
         # Modify default node params
         spec.config.name = "environment"
         spec.config.rate = rate
-        spec.config.process = process.ENVIRONMENT
+        spec.config.process = eagerx.process.ENVIRONMENT
         spec.config.color = color
         spec.config.log_level = log_level
         spec.config.inputs = []
@@ -138,10 +135,10 @@ class EnvNode(Node):
         self.obs_event.set()
 
 
-class ObservationsNode(Node):
+class ObservationsNode(eagerx.Node):
     @staticmethod
-    @register.spec("Observations", Node)
-    def spec(spec: NodeSpec, rate=1, log_level=WARN, color="yellow"):
+    @register.spec("Observations", eagerx.Node)
+    def spec(spec: eagerx.specs.NodeSpec, rate=1, log_level=eagerx.log.WARN, color="yellow"):
         """ObservationsNode spec"""
         # Initialize spec
         spec.initialize(ObservationsNode)
@@ -149,7 +146,7 @@ class ObservationsNode(Node):
         # Modify default node params
         spec.config.name = "env/observations"
         spec.config.rate = rate
-        spec.config.process = process.ENVIRONMENT
+        spec.config.process = eagerx.process.ENVIRONMENT
         spec.config.color = color
         spec.config.log_level = log_level
         spec.config.inputs = ["actions_set"]
@@ -171,10 +168,10 @@ class ObservationsNode(Node):
         raise NotImplementedError("This is a dummy class. Functionality is actually implemented in the Environment node.")
 
 
-class ActionsNode(Node):
+class ActionsNode(eagerx.Node):
     @staticmethod
-    @register.spec("Actions", Node)
-    def spec(spec: NodeSpec, rate=1, log_level=WARN, color="yellow"):
+    @register.spec("Actions", eagerx.Node)
+    def spec(spec: eagerx.specs.NodeSpec, rate=1, log_level=eagerx.log.WARN, color="yellow"):
         """ActionsNode spec"""
         # Initialize spec
         spec.initialize(ActionsNode)
@@ -182,7 +179,7 @@ class ActionsNode(Node):
         # Modify default node params
         spec.config.name = "env/actions"
         spec.config.rate = rate
-        spec.config.process = process.ENVIRONMENT
+        spec.config.process = eagerx.process.ENVIRONMENT
         spec.config.color = color
         spec.config.log_level = log_level
         spec.config.inputs = ["step"]
@@ -204,10 +201,17 @@ class ActionsNode(Node):
         raise NotImplementedError("This is a dummy class. Functionality is actually implemented in the Environment node.")
 
 
-class RenderNode(Node):
+class RenderNode(eagerx.Node):
     @staticmethod
-    @register.spec("Render", Node)
-    def spec(spec: NodeSpec, rate, display=True, log_level=WARN, color="grey"):
+    @register.spec("Render", eagerx.Node)
+    def spec(
+        spec: eagerx.specs.NodeSpec,
+        rate,
+        display=True,
+        log_level=eagerx.log.WARN,
+        color="grey",
+        process=eagerx.process.ENVIRONMENT,
+    ):
         """RenderNode spec"""
         # Initialize spec
         spec.initialize(RenderNode)
@@ -215,7 +219,7 @@ class RenderNode(Node):
         # Modify default node params
         spec.config.name = "env/render"
         spec.config.rate = rate
-        spec.config.process = process.ENVIRONMENT
+        spec.config.process = eagerx.process.ENVIRONMENT
         spec.config.color = color
         spec.config.log_level = log_level
         spec.config.inputs = ["image"]

--- a/eagerx/core/register.py
+++ b/eagerx/core/register.py
@@ -213,7 +213,7 @@ def engine_states(**engine_states) -> Callable:
 
     :param engine_states: The engine state's msg_type class.
     """
-    return functools.partial(_register_types, TYPE_REGISTER, "states", engine_states)
+    return functools.partial(_register_types, TYPE_REGISTER, "engine_states", engine_states)
 
 
 def bridge_config(**params: Optional[Union[bool, int, float, str, List, Dict]]) -> Callable:

--- a/eagerx/core/rx_pipelines.py
+++ b/eagerx/core/rx_pipelines.py
@@ -55,7 +55,7 @@ def init_node_pipeline(
     state_outputs,
     targets,
     cb_ft,
-    is_reactive,
+    sync,
     real_time_factor,
     simulate_delays,
     disposables,
@@ -67,7 +67,7 @@ def init_node_pipeline(
     Ns = BehaviorSubject(0)  # Number of started callbacks (i.e. number of planned Topics).
 
     # Throttle the callback trigger
-    Nct = throttle_callback_trigger(rate_node, Nc, E, is_reactive, real_time_factor, event_scheduler, node)
+    Nct = throttle_callback_trigger(rate_node, Nc, E, sync, real_time_factor, event_scheduler, node)
 
     # Create input channels
     zipped_inputs, zipped_input_flags = init_channels(
@@ -75,7 +75,7 @@ def init_node_pipeline(
         Nct,
         rate_node,
         inputs,
-        is_reactive,
+        sync,
         real_time_factor,
         simulate_delays,
         E,
@@ -92,7 +92,7 @@ def init_node_pipeline(
         real_reset,
         feedthrough,
         targets,
-        is_reactive,
+        sync,
         real_time_factor,
         simulate_delays,
         E,
@@ -199,7 +199,7 @@ def init_node(
     reset_disp = CompositeDisposable(eps_disp)
 
     # Gather reactive properties
-    is_reactive = node.is_reactive
+    sync = node.sync
     real_time_factor = node.real_time_factor
     simulate_delays = node.simulate_delays
 
@@ -349,7 +349,7 @@ def init_node(
                 state_outputs,
                 targets,
                 cb_ft,
-                is_reactive,
+                sync,
                 real_time_factor,
                 simulate_delays,
                 eps_disp,
@@ -407,7 +407,7 @@ def init_bridge_pipeline(
     SS_ho,
     SS_CL_ho,
     state_inputs,
-    is_reactive,
+    sync,
     real_time_factor,
     simulate_delays,
     E,
@@ -421,7 +421,7 @@ def init_bridge_pipeline(
     Ns = BehaviorSubject(0)  # Number of started callbacks (i.e. number of planned Topics).
 
     # Throttle the callback trigger
-    Nct = throttle_callback_trigger(rate_node, Nc, E, is_reactive, real_time_factor, event_scheduler, node)
+    Nct = throttle_callback_trigger(rate_node, Nc, E, sync, real_time_factor, event_scheduler, node)
     Nct_ho.on_next(Nct)
 
     # Create a tuple with None, to be consistent with feedthrough pipeline of init_node_pipeline
@@ -515,7 +515,7 @@ def init_bridge(
     reset_disp = CompositeDisposable(eps_disp)
 
     # Gather reactive properties
-    is_reactive = node.is_reactive
+    sync = node.sync
     real_time_factor = node.real_time_factor
     simulate_delays = node.simulate_delays
 
@@ -791,7 +791,7 @@ def init_bridge(
                 Nct,
                 rate_node,
                 inputs,
-                is_reactive,
+                sync,
                 real_time_factor,
                 simulate_delays,
                 end_reset["msg"],
@@ -830,7 +830,7 @@ def init_bridge(
                 SS_ho,
                 SS_CL_ho,
                 state_inputs,
-                is_reactive,
+                sync,
                 real_time_factor,
                 simulate_delays,
                 end_reset["msg"],

--- a/eagerx/core/specs.py
+++ b/eagerx/core/specs.py
@@ -874,6 +874,8 @@ class ObjectSpec(EntitySpec):
                     )
                 with getattr(self, component) as d:
                     d[cname] = mapping
+                # Select component per default
+                getattr(self.config, component).append(cname)
 
     def _initialize_bridge_config(self, bridge_id, bridge_config):
         # Add default config

--- a/eagerx/core/specs.py
+++ b/eagerx/core/specs.py
@@ -49,6 +49,9 @@ class ConverterSpec(EntitySpec):
         # Set default params
         defaults = get_default_params(spec_cls.initialize)
         with self.config as d:
+            if hasattr(spec_cls, "initial_obs"):
+                assert "initial_obs" not in defaults, "Argument clash! `initial_obs` is a reserved argument name."
+                defaults["initial_obs"] = None
             d.update(defaults)
 
     @property
@@ -58,6 +61,13 @@ class ConverterSpec(EntitySpec):
         The mutable parameters are:
 
         - The arguments of the subclass' :func:`~eagerx.core.entities.Converter.initialize` method.
+
+        - .. py:attribute:: Spec.config.initial_obs: Union[List, float, int, bool]
+
+            An observation that is used on t=0 if this space converter corresponds to an observation that is skipped at t=0
+            with `window` > 0.
+
+            .. note:: Can only be set for :class:`~eagerx.core.entities.SpaceConverter`.
 
         :return: (mutable) API to get/set parameters.
         """

--- a/eagerx/core/specs.py
+++ b/eagerx/core/specs.py
@@ -602,7 +602,7 @@ class BridgeSpec(BaseNodeSpec):
 
             Process in which the bridge is launched. See :class:`~eagerx.core.constants.process` for all options.
 
-        - .. py:attribute:: Spec.config.is_reactive: bool = True
+        - .. py:attribute:: Spec.config.sync: bool = True
 
             Flag that specifies whether we run reactive or asynchronous.
 

--- a/eagerx/core/supervisor.py
+++ b/eagerx/core/supervisor.py
@@ -185,16 +185,16 @@ class SupervisorNode(BaseNode):
 
 
 class Supervisor(object):
-    def __init__(self, name, message_broker, is_reactive, real_time_factor, simulate_delays):
+    def __init__(self, name, message_broker, sync, real_time_factor, simulate_delays):
         self.name = name
         self.ns = "/".join(name.split("/")[:2])
         self.mb = message_broker
         self.initialized = False
-        self.is_reactive = is_reactive
+        self.sync = sync
         self.has_shutdown = False
 
         # Prepare input & output topics
-        outputs, states, self.node = self._prepare_io_topics(self.name, is_reactive, real_time_factor, simulate_delays)
+        outputs, states, self.node = self._prepare_io_topics(self.name, sync, real_time_factor, simulate_delays)
 
         # Initialize reactive pipeline
         rx_objects, env_subjects = eagerx.core.rx_pipelines.init_supervisor(
@@ -212,7 +212,7 @@ class Supervisor(object):
             rospy.loginfo('Node "%s" initialized.' % self.name)
         self.initialized = True
 
-    def _prepare_io_topics(self, name, is_reactive, real_time_factor, simulate_delays):
+    def _prepare_io_topics(self, name, sync, real_time_factor, simulate_delays):
         params = get_param_with_blocking(name)
 
         # Get node
@@ -220,7 +220,7 @@ class Supervisor(object):
         node = node_cls(
             ns=self.ns,
             message_broker=self.mb,
-            is_reactive=is_reactive,
+            sync=sync,
             real_time_factor=real_time_factor,
             simulate_delays=simulate_delays,
             **params,

--- a/eagerx/core/view.py
+++ b/eagerx/core/view.py
@@ -126,8 +126,10 @@ class View(object):
     def _unlock(self):
         super(View, self).__setattr__("_unlocked", True)
 
-    def update(self, mapping):
+    def update(self, mapping, **kwargs):
         for key, value in mapping.items():
+            setattr(self, key, value)
+        for key, value in kwargs.items():
             setattr(self, key, value)
         return self
 

--- a/eagerx/core/view.py
+++ b/eagerx/core/view.py
@@ -1,7 +1,7 @@
 from yaml import dump
 import copy
 from eagerx.utils.utils import is_supported_type
-
+from typing import Dict, Any, Optional
 
 supported_types = (str, int, list, float, bool, dict)
 
@@ -126,9 +126,10 @@ class View(object):
     def _unlock(self):
         super(View, self).__setattr__("_unlocked", True)
 
-    def update(self, mapping, **kwargs):
-        for key, value in mapping.items():
-            setattr(self, key, value)
+    def update(self, mapping: Optional[Dict[str, Any]] = None, **kwargs):
+        if mapping is not None:
+            for key, value in mapping.items():
+                setattr(self, key, value)
         for key, value in kwargs.items():
             setattr(self, key, value)
         return self

--- a/eagerx/utils/node_utils.py
+++ b/eagerx/utils/node_utils.py
@@ -38,7 +38,7 @@ def launch_roscore():
     try:
         roscore.start()
     except roslaunch.core.RLException:
-        rospy.logwarn(
+        rospy.loginfo(
             "Roscore cannot run as another roscore/master is already running. Continuing without re-initializing the roscore."
         )
         roscore = None

--- a/examples/demo_async.py
+++ b/examples/demo_async.py
@@ -18,7 +18,7 @@ from time import time
 if __name__ == "__main__":
     # Define rate (depends on rate of gym env)
     rate = 20
-    is_reactive = True
+    sync = True
     real_time_factor = 2.0
 
     # Define object
@@ -47,7 +47,7 @@ if __name__ == "__main__":
     graph.load("./test.graph")
 
     # Define bridge
-    bridge = Bridge.make("GymBridge", rate=rate, is_reactive=is_reactive, real_time_factor=real_time_factor,
+    bridge = Bridge.make("GymBridge", rate=rate, sync=sync, real_time_factor=real_time_factor,
                          process=process.NEW_PROCESS)
 
     # Define step function
@@ -112,7 +112,7 @@ if __name__ == "__main__":
     # ax[-1].legend(handles=handles, ncol=4, prop={'size': 8}, loc='upper center', bbox_to_anchor=(0.5, -0.45), fancybox=True, shadow=True)
     # ax[-1].legend(handles=all_handles, ncol=6, prop={'size': 8}, loc='lower left', fancybox=True, shadow=True)
     ax[-1].set(xlabel="$t (s)$")
-    sync = "Reactive" if is_reactive else "Async"
+    sync = "Reactive" if sync else "Async"
     real_time_str = real_time_factor if real_time_factor > 0 else '"fast-as-possible"'
 
     fig.suptitle(

--- a/examples/example_debug_openai.py
+++ b/examples/example_debug_openai.py
@@ -18,7 +18,7 @@ def graph_engine(idx):
     roscore = initialize("eagerx_core", anonymous=True, log_level=log.DEBUG)
 
     gym_id = "Pendulum-v0"
-    is_reactive = True
+    sync = True
     rtf = 0
     p = 0
 
@@ -51,7 +51,7 @@ def graph_engine(idx):
     graph.connect(action="action", target=obj.actuators.action, window=1)
 
     # Define bridge
-    bridge = Bridge.make("GymBridge", rate=rate, is_reactive=is_reactive, real_time_factor=rtf, process=p)
+    bridge = Bridge.make("GymBridge", rate=rate, sync=sync, real_time_factor=rtf, process=p)
 
     # Initialize Environment
     name = str(time.time()).replace('.', '_')

--- a/examples/example_debug_test.py
+++ b/examples/example_debug_test.py
@@ -13,7 +13,7 @@ def graph_engine(idx):
     # Start roscore
     roscore = eagerx.initialize("eagerx_core", anonymous=True, log_level=eagerx.log.DEBUG)
 
-    is_reactive = True
+    sync = True
     rtf = 0
     p = 0
 
@@ -69,7 +69,7 @@ def graph_engine(idx):
     graph.gui()
 
     # Define bridge
-    bridge = eagerx.Bridge.make("TestBridge", rate=20, is_reactive=is_reactive, real_time_factor=rtf, process=bridge_p)
+    bridge = eagerx.Bridge.make("TestBridge", rate=20, sync=sync, real_time_factor=rtf, process=bridge_p)
 
     # Initialize Environment
     name = str(time.time()).replace(".", "_")

--- a/examples/example_graph_engine.py
+++ b/examples/example_graph_engine.py
@@ -26,7 +26,7 @@ def graph_engine(idx):
     graph.connect(action="act_1", target=arm.actuators.N8)
 
     # Define bridge
-    bridge = Bridge.make("TestBridge", rate=20, is_reactive=True, real_time_factor=1, process=process.ENVIRONMENT)
+    bridge = Bridge.make("TestBridge", rate=20, sync=True, real_time_factor=1, process=process.ENVIRONMENT)
 
     # Initialize Environment
     env = EagerxEnv(name=f"rx_{idx}", rate=7, graph=graph, bridge=bridge)

--- a/examples/example_openai.py
+++ b/examples/example_openai.py
@@ -38,7 +38,7 @@ if __name__ == "__main__":
     graph.load("./test.graph")
 
     # Define bridge
-    bridge = Bridge.make("GymBridge", rate=rate, is_reactive=True, real_time_factor=1, process=process.NEW_PROCESS)
+    bridge = Bridge.make("GymBridge", rate=rate, sync=True, real_time_factor=1, process=process.NEW_PROCESS)
 
     env = eagerx_gym.EagerxGym(name="rx", rate=rate, graph=graph, bridge=bridge)
     env.render(mode="human")

--- a/examples/example_skip.py
+++ b/examples/example_skip.py
@@ -25,7 +25,7 @@ def skip_run():
     graph.connect(source=arm.sensors.N6, observation="sens_1")
 
     # Define bridge
-    bridge = eagerx.Bridge.make("TestBridge", rate=20, is_reactive=True, real_time_factor=0,
+    bridge = eagerx.Bridge.make("TestBridge", rate=20, sync=True, real_time_factor=0,
                                 process=eagerx.process.ENVIRONMENT)
 
     # Initialize Environment

--- a/examples/example_skip.py
+++ b/examples/example_skip.py
@@ -29,7 +29,7 @@ def skip_run():
                                 process=eagerx.process.ENVIRONMENT)
 
     # Initialize Environment
-    env = eagerx.EagerxEnv(name="rx", rate=7, graph=graph, bridge=bridge)
+    env = eagerx.EagerxEnv(name="rx", rate=7, graph=graph, bridge=bridge, force_start=False)
 
     # First reset
     _ = env.reset()
@@ -44,11 +44,12 @@ def skip_run():
     print("\n[Finished]")
 
     # Shutdown test
-    env.shutdown()
+    # env.shutdown()
     if roscore:
         roscore.shutdown()
     print("\n[Shutdown]")
 
 
 if __name__ == "__main__":
+    skip_run()
     skip_run()

--- a/examples/example_skip.py
+++ b/examples/example_skip.py
@@ -1,0 +1,54 @@
+import eagerx
+
+# Implementation specific
+import tests.test  # noqa # pylint: disable=unused-import
+
+
+def skip_run():
+    # Start roscore
+    roscore = eagerx.initialize("eagerx_core", anonymous=True, log_level=eagerx.log.INFO)
+
+    # Define object
+    arm = eagerx.Object.make("Arm", "obj", actuators=["ref_vel"], sensors=["N6"], states=["N9"])
+
+    # Define graph
+    graph = eagerx.Graph.create(objects=[arm])
+
+    # Create mean-average filter
+    N1 = eagerx.Node.make("Process", "N1", rate=1.0, inputs=["in_1"], outputs=["out_1", "out_2"])
+    graph.add(N1)
+
+    # Connect sensors (= outputs of object)
+    graph.connect(action="act_1", target=N1.inputs.in_1)
+    graph.connect(source=N1.outputs.out_1, target=arm.actuators.ref_vel)
+    graph.connect(source=N1.outputs.out_2, observation="maf_state", skip=True, window=1, initial_obs=[666])
+    graph.connect(source=arm.sensors.N6, observation="sens_1")
+
+    # Define bridge
+    bridge = eagerx.Bridge.make("TestBridge", rate=20, is_reactive=True, real_time_factor=0,
+                                process=eagerx.process.ENVIRONMENT)
+
+    # Initialize Environment
+    env = eagerx.EagerxEnv(name="rx", rate=7, graph=graph, bridge=bridge)
+
+    # First reset
+    _ = env.reset()
+    env.render(mode="human")
+    action = env.action_space.sample()
+    for j in range(2):
+        print("\n[Episode %s]" % j)
+        for i in range(50):
+            _ = env.step(action)
+            env.render(mode="rgb_array")
+        env.reset()
+    print("\n[Finished]")
+
+    # Shutdown test
+    env.shutdown()
+    if roscore:
+        roscore.shutdown()
+    print("\n[Shutdown]")
+
+
+if __name__ == "__main__":
+    skip_run()

--- a/examples/example_test.py
+++ b/examples/example_test.py
@@ -132,7 +132,7 @@ if __name__ == "__main__":
     graph.load("./test.graph")
 
     # Define bridge
-    bridge = Bridge.make("TestBridge", rate=20, is_reactive=True, real_time_factor=0, process=bridge_p)
+    bridge = Bridge.make("TestBridge", rate=20, sync=True, real_time_factor=0, process=bridge_p)
 
     # Initialize Environment
     env = EagerxEnv(
@@ -172,6 +172,6 @@ if __name__ == "__main__":
     #  The bridges knows which inputs are nonreactive when the object is registered.
     #  - Nodes **must** at all times publish an output. Even, when a node did not received any new inputs and wishes to not publish.
     #  Perhaps, this constraint could be softened in the async setting, however the nodes that send "None", would then
-    #  not be agnostic (as they would break in the case is_reactive=True).
+    #  not be agnostic (as they would break in the case sync=True).
     #  - In the bridge definition of an object, there cannot be converters defined for the components related to the sensor and actuator.
     #  Reason for this is that if a converter would already be defined there, then it is not possible anymore to add another one in the agnostic graph.

--- a/tests/test/bridge.py
+++ b/tests/test/bridge.py
@@ -18,7 +18,7 @@ class TestBridgeNode(Bridge):
         # Initialize any simulator here, that is passed as reference to each simnode
         self.simulator = None
 
-        # If real_time bridge, assert that real_time_factor == 1 & is_reactive=False.
+        # If real_time bridge, assert that real_time_factor == 1 & sync=False.
 
         # Initialize nonreactive input (Only required for this test bridge implementation
         self.nonreactive_pub = rospy.Publisher(self.ns + nonreactive_address, UInt64, queue_size=0, latch=True)
@@ -29,7 +29,7 @@ class TestBridgeNode(Bridge):
         spec,
         rate,
         process: Optional[int] = process.NEW_PROCESS,
-        is_reactive: Optional[bool] = True,
+        sync: Optional[bool] = True,
         real_time_factor: Optional[float] = 0,
         simulate_delays: Optional[bool] = True,
         log_level: Optional[int] = ERROR,
@@ -42,7 +42,7 @@ class TestBridgeNode(Bridge):
         # Modify default bridge params
         spec.config.rate = rate
         spec.config.process = process
-        spec.config.is_reactive = is_reactive
+        spec.config.sync = sync
         spec.config.real_time_factor = real_time_factor
         spec.config.simulate_delays = simulate_delays
         spec.config.log_level = log_level

--- a/tests/test/bridge.py
+++ b/tests/test/bridge.py
@@ -71,7 +71,7 @@ class TestBridgeNode(Bridge):
         return "POST RESET RETURN VALUE"
 
     @register.outputs(tick=UInt64)
-    def callback(self, t_n: float, **kwargs: Optional[Msg]):
+    def callback(self, t_n: float):
         # Publish nonreactive input
         self.nonreactive_pub.publish(UInt64(data=self.num_ticks))
 
@@ -81,12 +81,3 @@ class TestBridgeNode(Bridge):
             rospy.logerr(
                 f"[{self.name}][callback]: ticks not equal (self.num_ticks={self.num_ticks}, node_tick={round(node_tick)})."
             )
-
-        # Verify that all timestamps are smaller or equal to node time
-        t_n = node_tick * (1 / self.rate)
-        for i in self.inputs:
-            name = i["name"]
-            if name in kwargs:
-                t_i = kwargs[name].info.t_in
-                if len(t_i) > 0 and not all((t.sim_stamp - t_n) <= 1e-7 for t in t_i if t is not None):
-                    rospy.logerr(f"[{self.name}][{name}]: Not all t_i are smaller or equal to t_n.")

--- a/tests/test/nodes.py
+++ b/tests/test/nodes.py
@@ -140,7 +140,7 @@ class TestNode(EngineNode):
 
         # Verify that # of ticks equals internal counter
         node_tick = t_n * self.rate
-        if self.is_reactive and not isclose(self.num_ticks, node_tick):
+        if self.sync and not isclose(self.num_ticks, node_tick):
             rospy.logerr(
                 f"[{self.name}][callback]: ticks not equal (self.num_ticks={self.num_ticks}, node_tick={round(node_tick)})."
             )

--- a/tests/test/objects.py
+++ b/tests/test/objects.py
@@ -21,7 +21,7 @@ class Arm(eagerx.Object):
         """Agnostic definition of the Arm object"""
         # Set state properties: space_converters
         spec.sensors.N6.space_converter = eagerx.SpaceConverter.make("Space_RosUInt64", [0], [100], dtype="uint64")
-        spec.sensors.N7.space_converter = eagerx.SpaceConverter.make("Space_RosUInt64", [0], [100], dtype="uint64")
+        # spec.sensors.N7.space_converter = eagerx.SpaceConverter.make("Space_RosUInt64", [0], [100], dtype="uint64")
         spec.sensors.N6.rate = rate
         spec.sensors.N7.rate = 2
 

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -222,7 +222,7 @@ def test_graph():
     graph.is_valid(plot=True)
 
     # Define bridge
-    bridge = Bridge.make("TestBridge", rate=20, is_reactive=False, real_time_factor=5.5, process=process.NEW_PROCESS)
+    bridge = Bridge.make("TestBridge", rate=20, sync=False, real_time_factor=5.5, process=process.NEW_PROCESS)
 
     # Initialize Environment
     env = EagerxEnv(

--- a/tests/test_graph_engine.py
+++ b/tests/test_graph_engine.py
@@ -27,7 +27,7 @@ def test_graph_engine():
     graph.connect(action="act_1", target=arm.actuators.N8)
 
     # Define bridge
-    bridge = Bridge.make("TestBridge", rate=20, is_reactive=True, real_time_factor=0, process=process.ENVIRONMENT)
+    bridge = Bridge.make("TestBridge", rate=20, sync=True, real_time_factor=0, process=process.ENVIRONMENT)
 
     # Initialize Environment
     env = EagerxEnv(name="graph_engine", rate=7, graph=graph, bridge=bridge)

--- a/tests/test_integration_openai_bridge.py
+++ b/tests/test_integration_openai_bridge.py
@@ -18,10 +18,10 @@ ENV = process.ENVIRONMENT
 
 @pytest.mark.timeout(60)
 @pytest.mark.parametrize(
-    "gym_id, eps, is_reactive, rtf, p",
+    "gym_id, eps, sync, rtf, p",
     [("Pendulum-v1", 2, True, 0, ENV), ("Pendulum-v1", 2, True, 0, NP), ("Acrobot-v1", 2, True, 0, ENV)],
 )
-def test_integration_openai_bridge(gym_id, eps, is_reactive, rtf, p):
+def test_integration_openai_bridge(gym_id, eps, sync, rtf, p):
     roscore = initialize("eagerx_core", anonymous=True, log_level=log.WARN)
 
     # Define rate (depends on rate of gym env)
@@ -52,11 +52,11 @@ def test_integration_openai_bridge(gym_id, eps, is_reactive, rtf, p):
     graph.connect(source=obj.sensors.done, observation="done", window=1)
     graph.connect(action="action", target=obj.actuators.action, window=1)
 
-    name = f"{name}_{eps}_{is_reactive}_{p}"
+    name = f"{name}_{eps}_{sync}_{p}"
 
     # Define bridge
     obj.gui("GymBridge")
-    bridge = Bridge.make("GymBridge", rate=rate, is_reactive=is_reactive, real_time_factor=rtf, process=p)
+    bridge = Bridge.make("GymBridge", rate=rate, sync=sync, real_time_factor=rtf, process=p)
 
     # Initialize Environment
     env = eagerx_gym.EagerxGym(name=name, rate=rate, graph=graph, bridge=bridge)

--- a/tests/test_integration_test_bridge.py
+++ b/tests/test_integration_test_bridge.py
@@ -31,12 +31,12 @@ def test_integration_test_bridge(eps, steps, sync, rtf, p):
     rate = 17
 
     # Define nodes
-    N1 = Node.make("Process", "N1", rate=18, process=node_p, inputs=["in_1"], outputs=["out_1"])
+    N1 = Node.make("Process", "N1", rate=18, process=node_p, inputs=["in_1", "in_2"], outputs=["out_1"])
     KF = Node.make("KalmanFilter", "KF", rate=19, process=node_p, inputs=["in_1", "in_2"], outputs=["out_1", "out_2"])
     N3 = ResetNode.make("RealReset", "N3", rate=rate, process=node_p, inputs=["in_1"], targets=["target_1"])
 
     # Define object
-    viper = Object.make("Viper", "obj", actuators=["N8"], sensors=["N6"], states=["N9"])
+    viper = Object.make("Viper", "obj", actuators=["N8"], sensors=["N6", "N7"], states=["N9"])
 
     # Define converter (optional)
     RosString_RosUInt64 = Converter.make("RosString_RosUInt64", test_arg="test")
@@ -60,6 +60,7 @@ def test_integration_test_bridge(eps, steps, sync, rtf, p):
 
     # Connect outputs N1
     graph.connect(source=N1.outputs.out_1, observation="obs_3")
+    graph.connect(source=viper.sensors.N7, target=N1.inputs.in_2)
 
     # Connect outputs & targets N3
     graph.connect(source=N3.outputs.out_1, target=viper.actuators.N8, converter=RosString_RosUInt64)

--- a/tests/test_integration_test_bridge.py
+++ b/tests/test_integration_test_bridge.py
@@ -17,15 +17,15 @@ ENV = process.ENVIRONMENT
 
 @pytest.mark.timeout(60)
 @pytest.mark.parametrize(
-    "eps, steps, is_reactive, rtf, p",
+    "eps, steps, sync, rtf, p",
     [(3, 3, True, 0, ENV), (20, 40, True, 0, NP), (3, 3, True, 4, NP), (20, 40, False, 4, NP), (3, 3, False, 4, ENV)],
 )
-def test_integration_test_bridge(eps, steps, is_reactive, rtf, p):
+def test_integration_test_bridge(eps, steps, sync, rtf, p):
     # Start roscore
     roscore = initialize("eagerx_core", anonymous=True, log_level=log.WARN)
 
     # Define unique name for test environment
-    name = f"{eps}_{steps}_{is_reactive}_{p}"
+    name = f"{eps}_{steps}_{sync}_{p}"
     node_p = p
     bridge_p = p
     rate = 17
@@ -72,7 +72,7 @@ def test_integration_test_bridge(eps, steps, is_reactive, rtf, p):
     graph.gui()
 
     # Define bridge
-    bridge = Bridge.make("TestBridge", rate=20, is_reactive=is_reactive, real_time_factor=rtf, process=bridge_p)
+    bridge = Bridge.make("TestBridge", rate=20, sync=sync, real_time_factor=rtf, process=bridge_p)
 
     # Initialize Environment
     env = EagerxEnv(

--- a/tests/test_skip.py
+++ b/tests/test_skip.py
@@ -31,7 +31,7 @@ def test_skip_observation(force_start):
     graph.connect(source=arm.sensors.N6, observation="sens_1")
 
     # Define bridge
-    bridge = eagerx.Bridge.make("TestBridge", rate=20, is_reactive=True, real_time_factor=0,
+    bridge = eagerx.Bridge.make("TestBridge", rate=20, sync=True, real_time_factor=0,
                                 process=eagerx.process.ENVIRONMENT)
 
     # Initialize Environment

--- a/tests/test_skip.py
+++ b/tests/test_skip.py
@@ -1,0 +1,52 @@
+import eagerx
+
+# Implementation specific
+import tests.test  # noqa # pylint: disable=unused-import
+import pytest
+
+
+@pytest.mark.timeout(20)
+def test_skip_observation():
+    # Start roscore
+    roscore = eagerx.initialize("eagerx_core", anonymous=True, log_level=eagerx.log.INFO)
+
+    # Define object
+    arm = eagerx.Object.make("Arm", "obj", actuators=["ref_vel"], sensors=["N6"], states=["N9"])
+
+    # Define graph
+    graph = eagerx.Graph.create(objects=[arm])
+
+    # Create mean-average filter
+    N1 = eagerx.Node.make("Process", "N1", rate=1.0, inputs=["in_1"], outputs=["out_1", "out_2"])
+    graph.add(N1)
+
+    # Connect sensors (= outputs of object)
+    graph.connect(action="act_1", target=N1.inputs.in_1)
+    graph.connect(source=N1.outputs.out_1, target=arm.actuators.ref_vel)
+    graph.connect(source=N1.outputs.out_2, observation="maf_state", skip=True, window=1, initial_obs=[666])
+    graph.connect(source=arm.sensors.N6, observation="sens_1")
+
+    # Define bridge
+    bridge = eagerx.Bridge.make("TestBridge", rate=20, is_reactive=True, real_time_factor=0,
+                                process=eagerx.process.ENVIRONMENT)
+
+    # Initialize Environment
+    env = eagerx.EagerxEnv(name="rx", rate=7, graph=graph, bridge=bridge)
+
+    # First reset
+    _ = env.reset()
+    env.render(mode="human")
+    action = env.action_space.sample()
+    for j in range(2):
+        print("\n[Episode %s]" % j)
+        for i in range(50):
+            _ = env.step(action)
+            env.render(mode="rgb_array")
+        env.reset()
+    print("\n[Finished]")
+
+    # Shutdown test
+    env.shutdown()
+    if roscore:
+        roscore.shutdown()
+    print("\n[Shutdown]")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- Allow the specification of an initial observation that is used when the observation is skipped and window>0. In that case, the initial observation will be used so that the observation, that is provided to the agent, complies with the observation space.
- Remove kwargs from Float32MultiArray
- Add ros to python path in separate bridge and node executables.
- Allow keyword updating of specs.
- fix engine_state info bug
- Unregister render subs/pubs when shutting down the environment
- Remote shutdown of environment if the environment already exists.
- Downgrade roscore warning to info if it is already launched.
- Select all registered sensors/actuators/states per default.
- Remove inputs from bridge callback
- Only add EngineNode outputs as input to bridge if EngineNode has tick as input.
- Refactor `is_reactive` to `sync`.
- Remove unnecessary call to space converter of sensors.
  
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- You can use the syntax `closes #100` if this solves the issue #100 -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/eager-dev/eagerx/blob/master/CONTRIBUTING.md) for new features and bug fixes)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation (update in the documentation)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTION](https://github.com/eager-dev/eagerx/blob/master/CONTRIBUTING.rst) guide (**required**)
- [x] I have used semantic commit messages such that my PR is [semantic](https://github.com/zeke/semantic-pull-requests) (**required**)
- [x] I have updated the changelog accordingly (**required**).
- [x] My change requires a change to the documentation.
- [x] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [x] I have updated the documentation accordingly.
- [x] I have reformatted the code using `make codestyle` (**required**)
- [x] I have checked the codestyle using `make check-codestyle` and `make lint` (**required**)
- [x] I have ensured `make pytest` passes. (**required**)
- [x] I have checked that the documentation builds using `make doc` (**required**)

Note: we are using a maximum length of 127 characters per line

<!--- This Template is an edited version of the one from https://github.com/DLR-RM/stable-baselines3 which is an edited version of the one from https://github.com/evilsocket/pwnagotchi/ -->
