### PR TITLE
fix: add interactive and shape arguments to gui methods for headless …

### DIFF
--- a/eagerx/core/specs.py
+++ b/eagerx/core/specs.py
@@ -1,6 +1,7 @@
-from typing import Dict, Optional, Union, Type, TYPE_CHECKING
+from typing import Dict, Optional, Union, Type, TYPE_CHECKING, List
 import gym
 from yaml import dump
+import numpy as np
 
 import eagerx
 from eagerx.core.space import Space
@@ -548,7 +549,9 @@ class ObjectSpec(EntitySpec):
         name = self._params["config"]["name"]
         return SpecView(self, depth=[depth], name=name, unlocked=unlocked)
 
-    def gui(self, engine_cls: Type["Engine"]) -> None:
+    def gui(
+        self, engine_cls: Type["Engine"], interactive: Optional[bool] = True, shape: Optional[List[int]] = None
+    ) -> Union[None, np.ndarray]:
         """Opens a graphical user interface of the object's engine implementation.
 
         .. note:: Requires `eagerx-gui`:
@@ -558,7 +561,13 @@ class ObjectSpec(EntitySpec):
 
             pip3 install eagerx-gui
 
-        :param engine_id: The `entity_id` with which the object's engine implementation was registered (e.g. "PybulletEngine").
+        :param engine_cls: The class engine (not instance!) that was used to register the engine implementation (e.g. "PybulletEngine").
+        :param interactive: If `True`, an interactive application is launched.
+                            Otherwise, an RGB render of the GUI is returned.
+                            This could be useful when using a headless machine.
+        :param shape: Specifies the shape of the returned render when `interactive` is `False`.
+                      If `interactive` is `True`, this argument is ignored.
+        :return: RGB render of the GUI if `interactive` is `False`.
         """
         import eagerx.core.register as register
 
@@ -566,7 +575,7 @@ class ObjectSpec(EntitySpec):
         engine_id = engine_cls.__module__ + "/" + engine_cls.__qualname__
         spec_copy._params["engine"] = {}
         graph = register.add_engine(spec_copy, engine_id)
-        graph.gui()
+        return graph.gui(interactive=interactive, shape=shape)
 
     @property
     def engine(self) -> Union[SpecView]:


### PR DESCRIPTION
…rendering of the gui

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Add arguments interactive and shape to gui methods for headless rendering of the gui.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- You can use the syntax `closes #100` if this solves the issue #100 -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/eager-dev/eagerx/blob/master/CONTRIBUTING.md) for new features and bug fixes)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTION](https://github.com/eager-dev/eagerx/blob/master/CONTRIBUTING.rst) guide (**required**)
- [x] I have used semantic commit messages such that my PR is [semantic](https://github.com/zeke/semantic-pull-requests) (**required**)
- [x] I have updated the changelog accordingly (**required**).
- [x] My change requires a change to the documentation.
- [ ] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [x] I have updated the documentation accordingly.
- [x] I have reformatted the code using `make codestyle` (**required**)
- [x] I have checked the codestyle using `make check-codestyle` and `make lint` (**required**)
- [x] I have ensured `make pytest` passes. (**required**)
- [x] I have checked that the documentation builds using `make doc` (**required**)

Note: we are using a maximum length of 127 characters per line

<!--- This Template is an edited version of the one from https://github.com/DLR-RM/stable-baselines3 which is an edited version of the one from https://github.com/evilsocket/pwnagotchi/ -->
