### PR TITLE
fix: refactor shape to resolution in gui and add filename arg

### DIFF
--- a/eagerx/core/graph.py
+++ b/eagerx/core/graph.py
@@ -972,7 +972,9 @@ class Graph:
             except AttributeError as e:
                 raise ImportError(f"Could not load `{key}`: {e}")
 
-    def gui(self, interactive: Optional[bool] = True, shape: Optional[List[int]] = None) -> Union[None, np.ndarray]:
+    def gui(
+        self, interactive: Optional[bool] = True, resolution: Optional[List[int]] = None, filename: Optional[str] = None
+    ) -> Union[None, np.ndarray]:
         """Opens a graphical user interface of the graph.
 
         .. note:: Requires `eagerx-gui`:
@@ -985,8 +987,10 @@ class Graph:
         :param interactive: If `True`, an interactive application is launched.
                             Otherwise, an RGB render of the GUI is returned.
                             This could be useful when using a headless machine.
-        :param shape: Specifies the shape of the returned render when `interactive` is `False`.
-                      If `interactive` is `True`, this argument is ignored.
+        :param resolution: Specifies the resolution of the returned render when `interactive` is `False`.
+                           If `interactive` is `True`, this argument is ignored.
+        :param filename: If provided, the GUI is rendered to an svg file with this name.
+                         If `interactive` is `True`, this argument is ignored.
         :return: RGB render of the GUI if `interactive` is `False`.
         """
         try:
@@ -998,17 +1002,19 @@ class Graph:
             return
 
         if interactive:
-            if shape is not None:
-                log.logwarn("Shape argument is ignored when launching GUI with interactive is True.")
+            if resolution is not None:
+                log.logwarn("Resolution argument is ignored when launching GUI with interactive is True.")
+            if filename is not None:
+                log.logwarn("Filename argument is ignored when launching GUI with interactive is True.")
             self._state = launch_gui(deepcopy(self._state))
             return None
         else:
-            if shape is not None:
+            if resolution is not None:
                 assert (
-                    type(shape) is list or type(shape) is np.ndarray
-                ), f"Invalid type for argument shape. Should be list or ndarray, but is {type(shape)}."
-                assert len(shape) == 2, f"Invalid length argument shape. Should be 2, but is {len(shape)}."
-            return render_gui(deepcopy(self._state), shape=shape)
+                    type(resolution) is list or type(resolution) is np.ndarray
+                ), f"Invalid type for argument resolution. Should be list or ndarray, but is {type(resolution)}."
+                assert len(resolution) == 2, f"Invalid length argument resolution. Should be 2, but is {len(resolution)}."
+            return render_gui(deepcopy(self._state), resolution=resolution)
 
     @staticmethod
     def _is_selected(state: Dict, entry: SpecView):

--- a/eagerx/core/graph_engine.py
+++ b/eagerx/core/graph_engine.py
@@ -610,7 +610,9 @@ class EngineGraph:
 
         return nodes, actuators, sensors
 
-    def gui(self, interactive: Optional[bool] = True, shape: Optional[List[int]] = None) -> Union[None, np.ndarray]:
+    def gui(
+        self, interactive: Optional[bool] = True, resolution: Optional[List[int]] = None, filename: Optional[str] = None
+    ) -> Union[None, np.ndarray]:
         """Opens a graphical user interface of the graph.
 
         .. note:: Requires `eagerx-gui`:
@@ -623,8 +625,10 @@ class EngineGraph:
         :param interactive: If `True`, an interactive application is launched.
                             Otherwise, an RGB render of the GUI is returned.
                             This could be useful when using a headless machine.
-        :param shape: Specifies the shape of the returned render when `interactive` is `False`.
-                      If `interactive` is `True`, this argument is ignored.
+        :param resolution: Specifies the resolution of the returned render when `interactive` is `False`.
+                           If `interactive` is `True`, this argument is ignored.
+        :param filename: If provided, the GUI is rendered to an svg file with this name.
+                         If `interactive` is `True`, this argument is ignored.
         :return: RGB render of the GUI if `interactive` is `False`.
         """
         try:
@@ -636,17 +640,19 @@ class EngineGraph:
             return
 
         if interactive:
-            if shape is not None:
-                log.logwarn("Shape argument is ignored when launching GUI with interactive is True.")
+            if resolution is not None:
+                log.logwarn("Resolution argument is ignored when launching GUI with interactive is True.")
+            if filename is not None:
+                log.logwarn("Filename argument is ignored when launching GUI with interactive is True.")
             self._state = launch_gui(deepcopy(self._state), is_engine=True)
             return None
         else:
-            if shape is not None:
+            if resolution is not None:
                 assert (
-                    type(shape) is list or type(shape) is np.ndarray
-                ), f"Invalid type for argument shape. Should be list or ndarray, but is {type(shape)}."
-                assert len(shape) == 2, f"Invalid length argument shape. Should be 2, but is {len(shape)}."
-            return render_gui(deepcopy(self._state), shape=shape, is_engine=True)
+                    type(resolution) is list or type(resolution) is np.ndarray
+                ), f"Invalid type for argument resolution. Should be list or ndarray, but is {type(resolution)}."
+                assert len(resolution) == 2, f"Invalid length argument resolution. Should be 2, but is {len(resolution)}."
+            return render_gui(deepcopy(self._state), resolution=resolution, is_engine=True)
 
     @staticmethod
     def _get_address(source: Tuple[str, str, str], target: Tuple[str, str, str]):

--- a/eagerx/core/specs.py
+++ b/eagerx/core/specs.py
@@ -550,7 +550,11 @@ class ObjectSpec(EntitySpec):
         return SpecView(self, depth=[depth], name=name, unlocked=unlocked)
 
     def gui(
-        self, engine_cls: Type["Engine"], interactive: Optional[bool] = True, shape: Optional[List[int]] = None
+        self,
+        engine_cls: Type["Engine"],
+        interactive: Optional[bool] = True,
+        resolution: Optional[List[int]] = None,
+        filename: Optional[str] = None,
     ) -> Union[None, np.ndarray]:
         """Opens a graphical user interface of the object's engine implementation.
 
@@ -565,8 +569,10 @@ class ObjectSpec(EntitySpec):
         :param interactive: If `True`, an interactive application is launched.
                             Otherwise, an RGB render of the GUI is returned.
                             This could be useful when using a headless machine.
-        :param shape: Specifies the shape of the returned render when `interactive` is `False`.
-                      If `interactive` is `True`, this argument is ignored.
+        :param resolution: Specifies the resolution of the returned render when `interactive` is `False`.
+                           If `interactive` is `True`, this argument is ignored.
+        :param filename: If provided, the GUI is rendered to an svg file with this name.
+                         If `interactive` is `True`, this argument is ignored.
         :return: RGB render of the GUI if `interactive` is `False`.
         """
         import eagerx.core.register as register
@@ -575,7 +581,7 @@ class ObjectSpec(EntitySpec):
         engine_id = engine_cls.__module__ + "/" + engine_cls.__qualname__
         spec_copy._params["engine"] = {}
         graph = register.add_engine(spec_copy, engine_id)
-        return graph.gui(interactive=interactive, shape=shape)
+        return graph.gui(interactive=interactive, resolution=resolution, filename=filename)
 
     @property
     def engine(self) -> Union[SpecView]:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Refactor argument shape in gui to resolution and add argument filename for saving svg of gui render.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- You can use the syntax `closes #100` if this solves the issue #100 -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/eager-dev/eagerx/blob/master/CONTRIBUTING.md) for new features and bug fixes)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTION](https://github.com/eager-dev/eagerx/blob/master/CONTRIBUTING.rst) guide (**required**)
- [x] I have used semantic commit messages such that my PR is [semantic](https://github.com/zeke/semantic-pull-requests) (**required**)
- [x] I have updated the changelog accordingly (**required**).
- [x] My change requires a change to the documentation.
- [ ] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [x] I have updated the documentation accordingly.
- [x] I have reformatted the code using `make codestyle` (**required**)
- [x] I have checked the codestyle using `make check-codestyle` and `make lint` (**required**)
- [x] I have ensured `make pytest` passes. (**required**)
- [x] I have checked that the documentation builds using `make doc` (**required**)

Note: we are using a maximum length of 127 characters per line

<!--- This Template is an edited version of the one from https://github.com/DLR-RM/stable-baselines3 which is an edited version of the one from https://github.com/evilsocket/pwnagotchi/ -->
