### PR TITLE
fix: filename argument now passed to gui render function

### DIFF
--- a/eagerx/core/graph.py
+++ b/eagerx/core/graph.py
@@ -1014,7 +1014,7 @@ class Graph:
                     type(resolution) is list or type(resolution) is np.ndarray
                 ), f"Invalid type for argument resolution. Should be list or ndarray, but is {type(resolution)}."
                 assert len(resolution) == 2, f"Invalid length argument resolution. Should be 2, but is {len(resolution)}."
-            return render_gui(deepcopy(self._state), resolution=resolution)
+            return render_gui(deepcopy(self._state), resolution=resolution, filename=filename)
 
     @staticmethod
     def _is_selected(state: Dict, entry: SpecView):

--- a/eagerx/core/graph_engine.py
+++ b/eagerx/core/graph_engine.py
@@ -652,7 +652,7 @@ class EngineGraph:
                     type(resolution) is list or type(resolution) is np.ndarray
                 ), f"Invalid type for argument resolution. Should be list or ndarray, but is {type(resolution)}."
                 assert len(resolution) == 2, f"Invalid length argument resolution. Should be 2, but is {len(resolution)}."
-            return render_gui(deepcopy(self._state), resolution=resolution, is_engine=True)
+            return render_gui(deepcopy(self._state), resolution=resolution, filename=filename, is_engine=True)
 
     @staticmethod
     def _get_address(source: Tuple[str, str, str], target: Tuple[str, str, str]):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Argument filename was not passed to gui render function. This is fixed now.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- You can use the syntax `closes #100` if this solves the issue #100 -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/eager-dev/eagerx/blob/master/CONTRIBUTING.md) for new features and bug fixes)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTION](https://github.com/eager-dev/eagerx/blob/master/CONTRIBUTING.rst) guide (**required**)
- [ ] I have used semantic commit messages such that my PR is [semantic](https://github.com/zeke/semantic-pull-requests) (**required**)
- [ ] I have updated the changelog accordingly (**required**).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.
- [ ] I have reformatted the code using `make codestyle` (**required**)
- [ ] I have checked the codestyle using `make check-codestyle` and `make lint` (**required**)
- [ ] I have ensured `make pytest` passes. (**required**)
- [ ] I have checked that the documentation builds using `make doc` (**required**)

Note: we are using a maximum length of 127 characters per line

<!--- This Template is an edited version of the one from https://github.com/DLR-RM/stable-baselines3 which is an edited version of the one from https://github.com/evilsocket/pwnagotchi/ -->
