### PR TITLE
fix: save/load API, target_channel bug, static node initialization, selected engine state bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@ coverage.xml
 *.pyc
 *.idea
 calibrate.launch
-test.graph
+*.graph
 *.zip
 log/
 *.egg-info

--- a/eagerx/core/env.py
+++ b/eagerx/core/env.py
@@ -1,6 +1,7 @@
 # EAGERX
 from eagerx.core.space import Space
-from eagerx.core.specs import NodeSpec, EngineSpec, BackendSpec, RxEngineState
+from eagerx.core.entities import Backend
+from eagerx.core.specs import NodeSpec, EngineSpec, BackendSpec, BaseNodeSpec
 from eagerx.core.entities import Node
 from eagerx.core.graph import Graph
 from eagerx.utils.node_utils import (
@@ -12,6 +13,7 @@ from eagerx.core.executable_engine import RxEngine
 from eagerx.core.supervisor import Supervisor, SupervisorNode
 from eagerx.core.rx_message_broker import RxMessageBroker
 from eagerx.core.constants import process
+from eagerx.core.constants import ENVIRONMENT, NEW_PROCESS, EXTERNAL, BackendException
 
 # OTHER IMPORTS
 import atexit
@@ -40,7 +42,7 @@ class BaseEnv(gym.Env):
     """
 
     def __init__(
-        self, name: str, rate: float, graph: Graph, engine: EngineSpec, backend: BackendSpec, force_start: bool
+        self, name: str, rate: float, graph: Graph, engine: EngineSpec, backend: BackendSpec = None, force_start: bool = True
     ) -> None:
         """Initializes  an environment with EAGERx dynamics.
 
@@ -52,6 +54,7 @@ class BaseEnv(gym.Env):
                        For every :class:`~eagerx.core.entities.Object` in the graph,
                        the corresponding engine implementations is chosen.
         :param backend: The backend that will govern the communication for this environment.
+                        Per default, the :class:`~eagerx.backends.single_process.SingleProcess` backend is used.
         :param force_start: If there already exists an environment with the same name, the existing environment is
                             first shutdown by calling the :func:`~eagerx.core.env.BaseEnv` method before initializing this
                             environment.
@@ -62,12 +65,16 @@ class BaseEnv(gym.Env):
         self.rate = rate
         self.initialized = False
         self.has_shutdown = False
-
-        # Register graph (unlinks the specs, reloads entities) .
-        self.graph, environment, engine, nodes, self.render_node = graph.register(engine)
+        self._is_initialized = dict()
+        self._launch_nodes = dict()
+        self._sp_nodes = dict()
 
         # Initialize backend
-        self.backend = self._init_backend(backend)
+        if backend is None:
+            from eagerx.backends.single_process import SingleProcess
+
+            backend = SingleProcess.make()
+        self.backend = Backend.from_cmd(self.ns, backend.config.entity_id, backend.config.log_level)
 
         # Check if there already exists an environment
         self._shutdown_srv = self.backend.register_environment(self.ns, force_start, self.shutdown)
@@ -81,40 +88,58 @@ class BaseEnv(gym.Env):
         # Initialize message broker
         self.mb = RxMessageBroker(owner="%s/%s" % (self.ns, "env"), backend=self.backend)
 
-        # Initialize supervisor node
-        self.supervisor_node, self.supervisor = self._init_supervisor(engine, nodes)
-        self._is_initialized = self.supervisor_node.is_initialized
+        # Register graph (returns unlinked specs with original graph & reloads entities).
+        self.graph, environment, engine, nodes, self.render_node = graph.register(rate, engine)
+
+        # Create supervisor spec (adds addresses of (engine)states to supervisor)
+        supervisor = self._create_supervisor(environment, engine, nodes)
+
+        # Upload parameters
+        self._upload_params(self.ns, self.backend, [supervisor, environment, engine] + nodes)
+
+        # Initialize environment
+        self.env = RxNode(name="%s/%s" % (self.ns, environment.config.name), message_broker=self.mb)
+        self.env.node_initialized()
+        self.env_node = self.env.node
+
+        # Initialize nodes
+        initialize_nodes(nodes, ENVIRONMENT, self.ns, self.mb, self._is_initialized, self._sp_nodes, self._launch_nodes)
 
         # Initialize engine
-        self._init_engine(engine, nodes)
+        initialize_nodes(
+            engine,
+            ENVIRONMENT,
+            self.ns,
+            self.mb,
+            self._is_initialized,
+            self._sp_nodes,
+            self._launch_nodes,
+            rxnode_cls=RxEngine,
+        )
 
-        # Create environment node
-        self.env_node, self.env = self._init_environment(environment, self.supervisor_node, self.mb)
-
-        # Register render node
-        if self.render_node:
-            nodes = [self.render_node] + nodes
-
-        # Register nodes
-        self._register_nodes(nodes)
+        # Initialize supervisor node
+        self.supervisor = Supervisor("%s/%s" % (self.ns, supervisor.config.name), self.mb, self.env_node)
+        self.supervisor.node_initialized()
+        self.supervisor_node = self.supervisor.node
+        self.mb.connect_io()
 
         # Implement clean up
         atexit.register(self.shutdown)
 
-    def _init_backend(self, backend: BackendSpec):
-        # Initialize backend
-        from eagerx.core.entities import Backend
+    @staticmethod
+    def _create_supervisor(environment: NodeSpec, engine: EngineSpec, nodes: List[NodeSpec]) -> BaseNodeSpec:
+        entity_type = f"{SupervisorNode.__module__}/{SupervisorNode.__name__}"
+        spec = Node.pre_make("N/a", entity_type)
+        spec.add_output("step", space=Space(shape=(), dtype="int64"))
 
-        backend = Backend.from_cmd(self.ns, backend.config.entity_id, backend.config.log_level)
+        spec.config.rate = environment.config.rate
+        spec.config.name = "env/supervisor"
+        spec.config.color = "yellow"
+        spec.config.process = process.ENVIRONMENT
+        spec.config.outputs = ["step"]
 
-        return backend
-
-    def _init_supervisor(self, engine: EngineSpec, nodes: List[NodeSpec]):
-        # Initialize supervisor
-        supervisor = self._create_supervisor()
-
-        # Get all states from objects & nodes
-        for i in [engine] + nodes:
+        # Get all states from all nodes
+        for i in [environment, engine] + nodes:
             for cname in i.params["config"]["states"]:
                 entity_name = i.config.name
                 name = f"{entity_name}/{cname}"
@@ -123,14 +148,15 @@ class BaseEnv(gym.Env):
                 space = i.params["states"][cname]["space"]
 
                 assert (
-                    name not in supervisor.params["states"]
+                    name not in spec.params["states"]
                 ), f'Cannot have duplicate states. State "{name}" is defined multiple times.'
 
                 mapping = dict(address=address, processor=processor, space=space)
-                with supervisor.states as d:
+                with spec.states as d:
                     d[name] = mapping
-                supervisor.config.states.append(name)
+                spec.config.states.append(name)
 
+        # Get all engine states
         for entity_name, obj in engine.objects.items():
             for cname, state in obj.engine_states.items():
                 name = f"{entity_name}/{cname}"
@@ -139,111 +165,38 @@ class BaseEnv(gym.Env):
                 space = state["space"].to_dict()
 
                 assert (
-                    name not in supervisor.params["states"]
+                    name not in spec.params["states"]
                 ), f'Cannot have duplicate states. State "{name}" is defined multiple times.'
 
                 mapping = dict(address=address, processor=processor, space=space)
-                with supervisor.states as d:
+                with spec.states as d:
                     d[name] = mapping
-                supervisor.config.states.append(name)
+                spec.config.states.append(name)
 
-        # Get info from engine on reactive properties
-        sync = engine.config.sync
-        real_time_factor = engine.config.real_time_factor
-        simulate_delays = engine.config.simulate_delays
+        return spec
 
-        # Create supervisor node
-        name = supervisor.config.name
-        supervisor.config.rate = self.rate
-        supervisor_params = supervisor.build(ns=self.ns)
-        self.backend.upload_params(self.ns, supervisor_params)
-        rx_supervisor = Supervisor(
-            "%s/%s" % (self.ns, name),
-            self.mb,
-            sync,
-            real_time_factor,
-            simulate_delays,
-        )
-        rx_supervisor.node_initialized()
-
-        # Connect io
-        self.mb.connect_io()
-        return rx_supervisor.node, rx_supervisor
-
-    def _init_engine(self, engine: EngineSpec, nodes: List[NodeSpec]) -> None:
-        # Check that reserved keywords are not already defined.
-        assert (
-            "node_names" not in engine.params["config"]
-        ), f'Keyword "{"node_names"}" is a reserved keyword within the engine params and cannot be used twice.'
-        assert (
-            "target_addresses" not in engine.params["config"]
-        ), f'Keyword "{"target_addresses"}" is a reserved keyword within the engine params and cannot be used twice.'
-        assert (
-            not engine.params["config"]["process"] == process.ENGINE
-        ), "Cannot initialize the engine inside the engine process, because it has not been launched yet. You can choose process.{ENVIRONMENT, EXTERNAL, NEW_PROCESS}."
-
-        # Extract node_names
-        node_names = ["environment", "env/supervisor"]
-        target_addresses = []
-        for i in nodes:
-            node_names.append(i.params["config"]["name"])
-            if "targets" in i.params["config"]:
-                for cname in i.params["config"]["targets"]:
-                    address = i.params["targets"][cname]["address"]
-                    target_addresses.append(address)
-        with engine.config as d:
-            d.node_names = node_names
-            d.target_addresses = target_addresses
-
-        # Convert engine states
-        for name, obj in engine.objects.items():
-            for cname, view in obj.engine_states.items():
-                address = f"{name}/states/{cname}"
-                processor = view.processor.to_dict() if view.processor else None
-                spec = RxEngineState(cname, address, view.state.to_dict(), processor, view.space.to_dict())
-                obj.engine_states[cname] = spec.build(ns=self.ns)
-
-        initialize_nodes(
-            engine,
-            process.ENVIRONMENT,
-            self.ns,
-            self.mb,
-            self.supervisor_node.is_initialized,
-            self.supervisor_node.sp_nodes,
-            self.supervisor_node.launch_nodes,
-            rxnode_cls=RxEngine,
-        )
-        wait_for_node_initialization(self._is_initialized, self.backend)  # Proceed after engine is initialized
-
-    def _init_environment(self, environment: NodeSpec, supervisor_node, message_broker):
-        # Check that env has at least one input & output.
-        assert (
-            len(environment.params["config"]["inputs"]) > 0
-        ), f'Environment "{self.name}" must have at least one input (i.e. input).'
-        assert (
-            len(environment.params["config"]["outputs"]) > 0
-        ), f'Environment "{self.name}" must have at least one action (i.e. output).'
-
-        # Check that all observation addresses are unique
-        addresses_obs = [environment.params["inputs"][cname]["address"] for cname in environment.params["config"]["inputs"]]
-        len(set(addresses_obs)) == len(
-            addresses_obs
-        ), "Duplicate observations found: %s. Make sure to only have unique observations" % (
-            set([x for x in addresses_obs if addresses_obs.count(x) > 1])
-        )
-
-        # Create env node
-        environment.config.rate = self.rate
-        name = environment.config.name
-        env_params = environment.build(ns=self.ns)
-        self.backend.upload_params(self.ns, env_params)
-        rx_env = RxNode(name="%s/%s" % (self.ns, name), message_broker=message_broker)
-        rx_env.node_initialized()
-
-        # Set env_node in supervisor
-        supervisor_node.set_environment(rx_env.node)
-
-        return rx_env.node, rx_env
+    @staticmethod
+    def _upload_params(ns: str, backend: Backend, nodes: List[BaseNodeSpec]) -> None:
+        for node in nodes:
+            name = node.config.name
+            msg = f"Node name '{ns}/{node.config.name}' already exists on the parameter server. Node names must be unique."
+            assert backend.get_param(f"{ns}/rate/{name}", None) is None, msg
+            # If no backend multiprocessing support, overwrite NEW_PROCESS to ENVIRONMENT
+            if node.config.process == NEW_PROCESS and not backend.MULTIPROCESSING_SUPPORT:
+                backend.logwarn_once(
+                    f"Backend '{backend.BACKEND}' does not support multiprocessing, "
+                    "so all nodes are launched in the ENVIRONMENT process."
+                )
+                node.config.process = ENVIRONMENT
+            # Raise error if external process is not supported
+            elif node.config.process == EXTERNAL and not backend.DISTRIBUTED_SUPPORT:
+                raise BackendException(
+                    f"Backend '{backend.BACKEND}' does not support distributed computation. "
+                    f"Therefore, this backend is incompatible with node '{name}', "
+                    f"because {name}.config.process=EXTERNAL."
+                )
+            params = node.build(ns=ns)
+            backend.upload_params(ns, params)
 
     @property
     def observation_space(self) -> gym.spaces.Space:
@@ -344,10 +297,10 @@ class BaseEnv(gym.Env):
         self._set_state(states)
 
         # Wait for nodes to be initialized
-        [node.node_initialized() for name, node in self.supervisor_node.sp_nodes.items()]
+        [node.node_initialized() for name, node in self._sp_nodes.items()]
         wait_for_node_initialization(self._is_initialized, self.backend)
 
-        # Initialize single process communication
+        # Initialize communication within this process
         self.mb.connect_io(print_status=True)
 
         self.backend.logdebug("Nodes initialized.")
@@ -362,10 +315,10 @@ class BaseEnv(gym.Env):
     def _shutdown(self):
         if not self.has_shutdown:
             self._shutdown_srv.unregister()
-            for address, node in self.supervisor_node.launch_nodes.items():
+            for address, node in self._launch_nodes.items():
                 self.backend.logdebug(f"[{self.name}] Send termination signal to '{address}'.")
                 node.terminate()
-            for _, rxnode in self.supervisor_node.sp_nodes.items():
+            for _, rxnode in self._sp_nodes.items():
                 rxnode: RxNode
                 if not rxnode.has_shutdown:
                     self.backend.logdebug(f"[{self.name}][{rxnode.name}] Shutting down.")
@@ -378,27 +331,6 @@ class BaseEnv(gym.Env):
             self.backend.delete_param(f"/{self.name}", level=1)
             self.backend.shutdown()
             self.has_shutdown = True
-
-    def _register_nodes(self, nodes: Union[List[NodeSpec], NodeSpec]) -> None:
-        assert not self.has_shutdown, "This environment has been shutdown."
-        # Look-up via <env_name>/<obj_name>/nodes/<component_type>/<component>: /rx/obj/nodes/sensors/pos_sensors
-        if not isinstance(nodes, list):
-            nodes = [nodes]
-
-        # Register nodes
-        [self.supervisor_node.register_node(n) for n in nodes]
-
-    @staticmethod
-    def _create_supervisor():
-        entity_type = f"{SupervisorNode.__module__}/{SupervisorNode.__name__}"
-        supervisor = Node.pre_make("N/a", entity_type)
-        supervisor.add_output("step", space=Space(shape=(), dtype="int64"))
-
-        supervisor.config.name = "env/supervisor"
-        supervisor.config.color = "yellow"
-        supervisor.config.process = process.ENVIRONMENT
-        supervisor.config.outputs = ["step"]
-        return supervisor
 
     def _reset(self, states: Dict) -> Dict:
         """A private method that should be called within :func:`~eagerx.core.env.BaseEnv.reset()`.

--- a/eagerx/core/graph.py
+++ b/eagerx/core/graph.py
@@ -823,6 +823,7 @@ class Graph:
         self, engine: Optional[EngineSpec] = None
     ) -> Tuple["Graph", NodeSpec, EngineSpec, List[NodeSpec], Optional[NodeSpec]]:
         state = deepcopy(self._state)
+        engine = deepcopy(engine)
         return self._register(state, engine)
 
     @staticmethod

--- a/eagerx/core/graph.py
+++ b/eagerx/core/graph.py
@@ -1495,7 +1495,7 @@ class Graph:
 
         # Register object's engine graph
         engine_graph = engine._register_object(spec)
-        nodes, actuators, sensors, connects = engine_graph.register(name)
+        nodes, actuators, sensors, connects = engine_graph.register()
 
         # Construct context
         context = {"ns": {"obj_name": name}}

--- a/eagerx/core/graph.py
+++ b/eagerx/core/graph.py
@@ -996,7 +996,7 @@ class Graph:
             skip=skip,
         )
 
-    def save(self, file: str):
+    def save(self, file: str) -> None:
         """Saves the graph state.
 
         The state is saved in *.yaml* format and contains the state of every added node, object, action, and observation
@@ -1006,7 +1006,6 @@ class Graph:
         """
         with open(file, "w") as outfile:
             yaml.dump(self._state, outfile, default_flow_style=False)
-        pass
 
     @classmethod
     def load(cls, file: str):

--- a/eagerx/core/graph.py
+++ b/eagerx/core/graph.py
@@ -92,7 +92,7 @@ class Graph:
         # Add action & observation node to list
         from eagerx.core.nodes import EnvNode
 
-        environment = EnvNode.make("Environment")
+        environment = EnvNode.make()
         nodes += [environment]
 
         # Create a state
@@ -820,16 +820,18 @@ class Graph:
             return entry
 
     def register(
-        self, engine: Optional[EngineSpec] = None
+        self, rate: float, engine: Optional[EngineSpec] = None
     ) -> Tuple["Graph", NodeSpec, EngineSpec, List[NodeSpec], Optional[NodeSpec]]:
         state = deepcopy(self._state)
         engine = deepcopy(engine)
-        return self._register(state, engine)
+        return self._register(state, rate, engine)
 
     @staticmethod
     def _register(
-        state, engine: Optional[EngineSpec] = None
+        state, rate: float, engine: Optional[EngineSpec] = None
     ) -> Tuple["Graph", NodeSpec, EngineSpec, List[NodeSpec], Optional[NodeSpec]]:
+        assert rate >= 0, f"The rate must be non-negative ('{rate}' !=> 0)."
+
         # Add engine
         if engine:
             Graph._add_engine(state, engine)
@@ -876,25 +878,52 @@ class Graph:
             source_dtype = state["nodes"][source_name][source_comp][source_cname]["space"]["dtype"]
             state["nodes"][target_name][target_comp][target_cname]["dtype"] = source_dtype
 
-        # Initialize param objects
+        # Extract node_names
+        node_names = ["env/supervisor"]
+        target_addresses = []
+        for _i, params in state["nodes"].items():
+            if params["config"]["name"] == "engine":
+                continue
+            node_names.append(params["config"]["name"])
+            if "targets" in params["config"]:
+                for cname in params["config"]["targets"]:
+                    address = params["targets"][cname]["address"]
+                    target_addresses.append(address)
+        assert "node_names" not in engine.config, f'Keyword "{"node_names"}" is a reserved keyword.'
+        assert "target_addresses" not in engine.config, f'Keyword "{"target_addresses"}" is a reserved keyword.'
+        msg = "An Engine can only be launched with the options {ENVIRONMENT, EXTERNAL, NEW_PROCESS}."
+        assert not engine.config.process == eagerx.ENGINE, msg
+        with engine.config as d:
+            d.node_names = node_names
+            d.target_addresses = target_addresses
+
+        # Get specs
+        environment, engine, nodes, render = Graph._get_all_node_specs(state)
+
+        # Set environment rate
+        environment.config.rate = rate
+        return Graph(deepcopy(state)), environment, engine, nodes, render
+
+    @staticmethod
+    def _get_all_node_specs(state: Dict) -> Tuple[NodeSpec, EngineSpec, List[NodeSpec], Optional[NodeSpec]]:
+        # Get specs
         nodes = []
         render: Optional[NodeSpec] = None
-        environment: NodeSpec = None
         engine: EngineSpec = None
+        environment: NodeSpec = None
         for name, params in state["nodes"].items():
-            assert "node_type" in params, f"Node `{name}` is not a valid node. have all Objects been replaced by nodes?"
+            assert "node_type" in params, f"Node `{name}` is not a valid node. Have all Objects been replaced by nodes?"
             if name == "environment":
                 environment = NodeSpec(params)
             elif name == "env/render":
                 render = NodeSpec(params)
+                nodes.append(render)
             elif name == "engine":
                 engine = EngineSpec(params)
             else:
                 nodes.append(NodeSpec(params))
-
         assert environment, "No environment node defined in the graph."
-        assert engine, "No engine node defined in the graph."
-        return Graph(state), environment, engine, nodes, render
+        return environment, engine, nodes, render
 
     def render(
         self,

--- a/eagerx/core/graph_engine.py
+++ b/eagerx/core/graph_engine.py
@@ -526,7 +526,7 @@ class EngineGraph:
 
     def register(self):
         """Returns the nodes that make up this subgraph,
-         and their relation to the registered actuators and sensors."""
+        and their relation to the registered actuators and sensors."""
 
         # Check if valid graph.
         assert self.is_valid(plot=False), "Graph not valid."
@@ -597,14 +597,15 @@ class EngineGraph:
                 else:
                     spec = NodeSpec(params)
                     flag = True if "tick" not in spec.config.inputs else len(spec.config.outputs) > 0
-                    assert flag, f"If Node `{spec.config.name}` must run synchronized with the Engine, " \
-                                 f"it must have at least 1 (dummy?) output."
+                    assert flag, (
+                        f"If Node `{spec.config.name}` must run synchronized with the Engine, "
+                        f"it must have at least 1 (dummy?) output."
+                    )
 
                     # Put node name into object namespace
                     name = f"$(ns obj_name)/{spec.config.name}"
                     spec.config.name = name
                     params = spec.params
-
 
                     # Substitute placeholder args of simnode
                     context = {"ns": {"node_name": name}, "config": params["config"]}

--- a/eagerx/core/rx_operators.py
+++ b/eagerx/core/rx_operators.py
@@ -262,12 +262,6 @@ def switch_to_reset():
     return _switch_to_reset
 
 
-def combine_dict(acc, x):
-    for key, item in acc.items():
-        item += x[key]
-    return acc
-
-
 def create_msg_tuple(name: str, node_tick: int, msg: List[Any], stamp: List[Stamp], done: bool = None):
     info = Info(name=name, node_tick=node_tick, t_in=stamp, done=done)
     return Msg(info, msg)
@@ -873,28 +867,6 @@ def init_callback_pipeline(
             ops.share(),
         )
     return d_msg, output_stream
-
-
-def get_node_params(node, node_name):
-    node_params = eagerx.utils.utils.get_param_with_blocking(node_name, node.backend)
-    if node_params is None:
-        raise ValueError(
-            "Parameters for object registry request (%s) not found on parameter server. Timeout: object (%s) not registered."
-            % (node_name, node_name)
-        )
-    return node_params
-
-
-def extract_node_reset(ns, node_params, sp_nodes, launch_nodes):
-    # name = node_params["config"]["name"]
-    # nf = dict(name=name, address="%s/%s/end_reset" % (ns, name), msg=Subject(), dtype="bool")
-    return dict(
-        inputs=[],
-        state_inputs=[],
-        node_flags=[],  # [nf],
-        sp_nodes=sp_nodes,
-        launch_nodes=launch_nodes,
-    )
 
 
 def switch_with_check_pipeline(init_ho=None):

--- a/eagerx/core/rx_operators.py
+++ b/eagerx/core/rx_operators.py
@@ -726,7 +726,9 @@ def init_target_channel(states, scheduler, node):
             remap_target(s["name"], node.sync, node.real_time_factor),
         )
         channels.append(c)
-    return rx.zip(*channels).pipe(regroup_inputs(node, is_input=False))
+    # HACK!: Why do we sometimes receive the targets twice? And is the first received the new target or the old one?
+    #        In this way, we risk reusing a target twice.
+    return rx.zip(*channels).pipe(regroup_inputs(node, is_input=False), ops.take(1))
 
 
 def merge_dicts(dict_1, dict_2):

--- a/eagerx/core/rx_operators.py
+++ b/eagerx/core/rx_operators.py
@@ -769,7 +769,10 @@ def call_state_reset(state):
     def _call_state_reset(source):
         def subscribe(observer, scheduler=None):
             def on_next(state_msg):
-                state.reset(state=state_msg.msgs[0])
+                try:
+                    state.reset(state=state_msg.msgs[0])
+                except Exception as e:
+                    observer.on_error(e)
                 observer.on_next(state_msg)
 
             return source.subscribe(on_next, observer.on_error, observer.on_completed, scheduler)

--- a/eagerx/core/rx_pipelines.py
+++ b/eagerx/core/rx_pipelines.py
@@ -510,7 +510,7 @@ def init_engine(
     # Initialization ##########################################################
     ###########################################################################
     # Prepare scheduler
-    tp_scheduler = ThreadPoolScheduler(max_workers=max(1, len(engine_state_inputs)))
+    tp_scheduler = ThreadPoolScheduler(max_workers=max(5, len(engine_state_inputs)))
     event_scheduler = EventLoopScheduler()
     eps_disp = CompositeDisposable()
     reset_disp = CompositeDisposable(eps_disp)
@@ -710,6 +710,7 @@ def init_engine(
     ResetTrigger = Subject()
     ss_flags = simstate_inputs.pipe(
         ops.map(lambda s: init_state_resets(ns, s, ResetTrigger, event_scheduler, tp_scheduler, node)),
+        trace_observable("EngineState", node),
         ops.share(),
     )
     check_simSS, simSS, simSS_ho = switch_with_check_pipeline()

--- a/eagerx/core/specs.py
+++ b/eagerx/core/specs.py
@@ -1,3 +1,4 @@
+from warnings import warn
 import copy
 from typing import Dict, Optional, Union, Type, TYPE_CHECKING, List
 import gym
@@ -746,10 +747,14 @@ class EngineSpec(BaseNodeSpec):
         assert name in self.objects, f"There is no Object called `{name}' in engine.objects. First add the Object."
         states = spec.engine.states
         for cname in list(states.keys()):
-            if states[cname] is not None:
-                self._add_engine_state(
-                    name, cname, states[cname], spec.states[cname]["space"], spec.states[cname]["processor"]
-                )
+            if cname in spec.config.states:
+                if states[cname] is not None:
+                    self._add_engine_state(
+                        name, cname, states[cname], spec.states[cname]["space"], spec.states[cname]["processor"]
+                    )
+                else:
+                    warn(f"Engine state `{cname}` for object `{name}` will be ignored. "
+                         f"There is no implementation provided for it in Engine `{self.config.entity_id}`.")
 
     def _add_engine_state(self, name, cname, engine_state, space, processor=None):
         with self.objects[name].engine_states as s:

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -275,6 +275,13 @@ def test_graph():
 
     # Shutdown test
     env.shutdown()
+
+    # Save/load full environment
+    env.save("./full.graph")
+    loaded_env = eagerx.BaseEnv.load(name="load", file="./full.graph")
+    sampled = loaded_env.state_space.sample()
+    loaded_env._reset(sampled)
+    loaded_env.shutdown()
     print("\n[Shutdown]")
 
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

This PR solves:

- An occasional deadlock where the `target_channel` is received multiple times during the first reset.
- Close #217
- Only initialize selected `engine_states` instead of all states that were implemented.
- Statically initialize nodes. Closes #216 
- Cleans up `BaseEnv` initialization.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- You can use the syntax `closes #100` if this solves the issue #100 -->
- [x] I have raised an issue to propose this change ([required](https://github.com/eager-dev/eagerx/blob/master/CONTRIBUTING.md) for new features and bug fixes)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTION](https://github.com/eager-dev/eagerx/blob/master/CONTRIBUTING.rst) guide (**required**)
- [x] I have used semantic commit messages such that my PR is [semantic](https://github.com/zeke/semantic-pull-requests) (**required**)
- [x] I have updated the changelog accordingly (**required**).
- [x] My change requires a change to the documentation.
- [x] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [x] I have updated the documentation accordingly.
- [x] I have reformatted the code using `make codestyle` (**required**)
- [x] I have checked the codestyle using `make check-codestyle` and `make lint` (**required**)
- [x] I have ensured `make pytest` passes. (**required**)
- [x] I have checked that the documentation builds using `make doc` (**required**)

Note: we are using a maximum length of 127 characters per line

<!--- This Template is an edited version of the one from https://github.com/DLR-RM/stable-baselines3 which is an edited version of the one from https://github.com/evilsocket/pwnagotchi/ -->
